### PR TITLE
Fix non-page login

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ function _login(email, password, loginOptions, callback) {
       return [utils.get('https://www.facebook.com/'+ctx.globalOptions.pageId+'/messages/?section=messages&subsection=inbox', ctx.jar), ctx, mergeWithDefaults, api];
     },
     function maybePageLogin(resData, ctx, mergeWithDefaults, api) {
-      if(!resData) return [api];
+      if(!resData) return [null, api];
 
       var url = utils.getFrom(resData.body, 'window.location.replace("https:\\/\\/www.facebook.com\\', '");').split('\\').join('');
       url = url.substring(0, url.length - 1);


### PR DESCRIPTION
When logging in with a standard account, the `api` variable was not properly passed to the callback.