### PR TITLE
Fixed resData.entries error

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Given a person's full name will do a Facebook Graph search and return all the id
 __Arguments__
 
 * `name` - A string being the name of the person you're looking for.
-* `callback(err, obj)` - A callback called when the search is done (either with an error or with the resulting object). `obj` contains and array called entries which contains all the users that facebook graph search found, ordered by "importance".
+* `callback(err, obj)` - A callback called when the search is done (either with an error or with the resulting object). `obj` is an array which contains all of the users that facebook graph search found, ordered by "importance".
 
 __Example__
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ login('config.json', function(err, api) {
         if(err) return callback(err);
         
         // Send the message to the best match (best by Facebook's criteria)
-        var thread_id = data.payload.entries[0].uid;
+        var thread_id = data[0].uid;
         api.sendMessage(msg, thread_id);
     });
 });

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ login('config.json', function(err, api) {
         if(err) return callback(err);
         
         // Send the message to the best match (best by Facebook's criteria)
-        var thread_id = data.entries[0].uid;
+        var thread_id = data.payload.entries[0].uid;
         api.sendMessage(msg, thread_id);
     });
 });

--- a/src/getUserId.js
+++ b/src/getUserId.js
@@ -22,7 +22,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       if(resData.payload.entries[0].type !== "user") {
         return callback({error: "Couldn't find a user with name " + name + ". Best match: " + resData.payload.entries[0].path});
       }
-      callback(null, resData);
+      callback(null, resData.payload.entries);
     })
     .catch(function(err) {
       log.error("Error in getUserId", err);

--- a/src/getUserId.js
+++ b/src/getUserId.js
@@ -18,8 +18,9 @@ module.exports = function(mergeWithDefaults, api, ctx) {
     utils.get("https://www.facebook.com/ajax/typeahead/search.php", ctx.jar, form)
     .then(utils.parseResponse)
     .then(function(resData) {
-      if(resData.entries[0].type !== "user") {
-        return callback({error: "Couldn't find a user with name " + name + ". Best match: " + resData.entries[0].path});
+
+      if(resData.payload.entries[0].type !== "user") {
+        return callback({error: "Couldn't find a user with name " + name + ". Best match: " + resData.payload.entries[0].path});
       }
       callback(null, resData);
     })

--- a/src/sendDirectMessage.js
+++ b/src/sendDirectMessage.js
@@ -17,7 +17,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       if(err) return callback(err);
 
       // TODO: find the actual best entry
-      var thread_id = data.payload.entries[0].uid;
+      var thread_id = data[0].uid;
       api.sendMessage(msg, thread_id, callback);
     });
   };

--- a/src/sendDirectMessage.js
+++ b/src/sendDirectMessage.js
@@ -17,7 +17,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       if(err) return callback(err);
 
       // TODO: find the actual best entry
-      var thread_id = data.entries[0].uid;
+      var thread_id = data.payload.entries[0].uid;
       api.sendMessage(msg, thread_id, callback);
     });
   };

--- a/src/sendDirectSticker.js
+++ b/src/sendDirectSticker.js
@@ -17,7 +17,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       if(err) return callback(err);
 
       // TODO: find the actual best entry
-      var thread_id = data.entries[0].uid;
+      var thread_id = data.payload.entries[0].uid;
       api.sendSticker(sticker_id, thread_id, callback);
     });
   };

--- a/src/sendDirectSticker.js
+++ b/src/sendDirectSticker.js
@@ -17,7 +17,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       if(err) return callback(err);
 
       // TODO: find the actual best entry
-      var thread_id = data.payload.entries[0].uid;
+      var thread_id = data[0].uid;
       api.sendSticker(sticker_id, thread_id, callback);
     });
   };


### PR DESCRIPTION
Fixed the following issue, https://github.com/Schmavery/facebook-chat-api/issues/26, by changing references to `resData.entries` to `resData.payload.entries`
