### PR TITLE
Adding getCurrentUserId to API

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,8 @@ function _login(email, password, loginOptions, callback) {
         'getFriendsList',
         'getUserInfo',
         'removeUserFromGroup',
-        'addUserToGroup'];
+        'addUserToGroup',
+        'getCurrentUserId'];
 
       var mergeWithDefaults = utils.makeMergeWithDefaults(html, userId);
 

--- a/src/getCurrentUserId.js
+++ b/src/getCurrentUserId.js
@@ -1,0 +1,28 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function getCurrentUserId(callback) {
+    utils.get("https://www.facebook.com/me", ctx.jar)
+    .then(function(resData) {
+      var splitData = resData.req._headers.cookie.split("; ");
+
+      var i = 0;
+
+      while (i < splitData.length) {
+        var d = (splitData[i]).split("=");
+        if(d[0] == "c_user") {
+          callback(null, d[1]);
+          return;
+        }
+      }
+    })
+    .catch(function(err) {
+      log.error("Error in getCurrentUserId", err);
+      return callback(err);
+    });
+  };
+};

--- a/src/getCurrentUserId.js
+++ b/src/getCurrentUserId.js
@@ -8,16 +8,17 @@ module.exports = function(mergeWithDefaults, api, ctx) {
   return function getCurrentUserId(callback) {
     utils.get("https://www.facebook.com/me", ctx.jar)
     .then(function(resData) {
-      var splitData = resData.req._headers.cookie.split("; ");
+      var splitData = resData.req._headers.cookie.split(";");
 
       var i = 0;
-
+      
       while (i < splitData.length) {
         var d = (splitData[i]).split("=");
-        if(d[0] == "c_user") {
-          callback(null, d[1]);
+        if(d[0].trim() == "c_user") {
+          callback(d[1]);
           return;
         }
+        i++;
       }
     })
     .catch(function(err) {


### PR DESCRIPTION
This is a simple way to get the current REAL user ID.

The regular Facebook API gives a new ID per-app which was not helpful in my case, thankfully the cookies hold the delicious solution. 

    api.getCurrentUserId(function(userID) {
        console.log("Your REAL user ID is " + userID);
    });
