### PR TITLE
Add api.sendTypingIndicator

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,8 @@ function _login(email, password, loginOptions, callback) {
         'getFriendsList',
         'getUserInfo',
         'removeUserFromGroup',
-        'addUserToGroup'];
+        'addUserToGroup',
+        'typing'];
 
       var mergeWithDefaults = utils.makeMergeWithDefaults(html, userId);
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function _login(email, password, loginOptions, callback) {
         'getUserInfo',
         'removeUserFromGroup',
         'addUserToGroup',
-        'typing'];
+        'sendTypingIndicator'];
 
       var mergeWithDefaults = utils.makeMergeWithDefaults(html, userId);
 

--- a/src/typing.js
+++ b/src/typing.js
@@ -1,0 +1,37 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function typing(thread_id, callback) {
+    if(!callback) callback = function() {};
+    var form = mergeWithDefaults({
+      typ: 1,
+      to: '',
+      source: 'mercury-chat',
+      thread: thread_id
+    });
+
+    // Check if thread is single person chat or group chat
+    // More info on this is in api.sendMessage
+    api.getUserInfo(thread_id, function(err, res) {
+      // If id is single person chat 
+      if(!(res instanceof Array)) {
+        form.to = thread_id
+      }
+
+      utils.post("https://www.facebook.com/ajax/messaging/typ.php", ctx.jar, form)
+      .then(utils.parseResponse)
+      .then(function(resData) {
+        callback();
+      })
+      .catch(function(err) {
+        log.error("Error in typing", err);
+        return callback(err);
+      });
+    });
+
+  };
+};


### PR DESCRIPTION
Send typing indicator for other users in the chat to see.

The typing indicator will disappear automatically after 30 seconds or after sending a message (```api.sendMessage```).

However, this can be overridden by sending a request again, with the field ```typ``` being ```0``` instead of ```1```.
Still thinking the best idea to implement this tho.

Any suggestion?