### PR TITLE
Add attachment upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,8 @@ function _login(email, password, loginOptions, callback) {
         'removeUserFromGroup',
         'addUserToGroup',
         'sendTypingIndicator',
-        'getCurrentUserId'];
+        'getCurrentUserId',
+        'uploadAttachment'];
 
       var mergeWithDefaults = utils.makeMergeWithDefaults(html, userId);
 

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -59,7 +59,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       form['message_batch[0][gif_ids]'] = [];
       form['message_batch[0][file_ids]'] = [];
 
-      if (!utils.getType(msg.attachment) !== 'Array') {
+      if (utils.getType(msg.attachment) !== 'Array') {
         msg.attachment = [msg.attachment]
       }
 

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -7,8 +7,8 @@ var log = require("npmlog");
 module.exports = function(mergeWithDefaults, api, ctx) {
   return function sendMessage(msg, thread_id, callback) {
     if(!callback) callback = function() {};
-    if(typeof msg !== "string" && typeof msg !== "object")
-      return callback({error: "Message should be of type string or object and not " + typeof msg + "."});
+    if(typeof msg !== "string" && !utils.checkType(msg, "Object"))
+      return callback({error: "Message should be of type string or object and not " + utils.getType(msg) + "."});
     if(typeof thread_id !== "number" && typeof thread_id !== "string")
       return callback({error: "Thread_id should be of type number or string and not " + typeof thread_id + "."});
 

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -7,9 +7,14 @@ var log = require("npmlog");
 module.exports = function(mergeWithDefaults, api, ctx) {
   return function sendMessage(msg, thread_id, callback) {
     if(!callback) callback = function() {};
-    if(typeof msg !== "string") return callback({error: "Message should be of type string and not " + typeof msg + "."});
+    if(typeof msg !== "string" && typeof msg !== "object")
+      return callback({error: "Message should be of type string or object and not " + typeof msg + "."});
     if(typeof thread_id !== "number" && typeof thread_id !== "string")
       return callback({error: "Thread_id should be of type number or string and not " + typeof thread_id + "."});
+
+    if (typeof msg === "string") {
+      msg = { body: msg }
+    }
 
     var messageAndThreadID = utils.generateMessageID(ctx.clientid);
 
@@ -28,7 +33,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       'message_batch[0][is_spoof_warning]' : false,
       'message_batch[0][source]' : 'source:chat:web',
       'message_batch[0][source_tags][0]' : 'source:chat',
-      'message_batch[0][body]' : msg ? msg.toString() : "",
+      'message_batch[0][body]' : msg.body ? msg.body.toString() : "",
       'message_batch[0][html_body]' : false,
       'message_batch[0][ui_push_phase]' : 'V3',
       'message_batch[0][status]' : '0',
@@ -40,42 +45,73 @@ module.exports = function(mergeWithDefaults, api, ctx) {
       'message_batch[0][signatureID]' : utils.getSignatureId(),
     });
 
-    // We're doing a query to this to check if the given id is the id of
-    // a user or of a group chat. The form will be different depending
-    // on that.
-    api.getUserInfo(thread_id, function(err, res) {
-      // This means that thread_id is the id of a user, and the chat
-      // is a single person chat
-      if(!(res instanceof Array)) {
-        form['message_batch[0][client_thread_id]'] = "user:"+thread_id;
-        form['message_batch[0][specific_to_list][0]'] = "fbid:"+thread_id;
-        form['message_batch[0][specific_to_list][1]'] = "fbid:"+ctx.userId;
+    if (msg.attachment) {
+      form['message_batch[0][has_attachment]'] = true;
+      form['message_batch[0][image_ids]'] = [];
+      form['message_batch[0][gif_ids]'] = [];
+      form['message_batch[0][file_ids]'] = [];
+
+      if (!(msg.attachment instanceof Array)) {
+        msg.attachment = [msg.attachment]
       }
 
-      if(ctx.globalOptions.pageId) {
-        form['message_batch[0][author]'] = "fbid:" + ctx.globalOptions.pageId;
-        form['message_batch[0][specific_to_list][1]'] = "fbid:" + ctx.globalOptions.pageId;
-        form['message_batch[0][creator_info][creatorID]'] = ctx.userId;
-        form['message_batch[0][creator_info][creatorType]'] = "direct_admin";
-        // form['message_batch[0][creator_info][creatorName]'] = Marc Zuckerbot
-        form['message_batch[0][creator_info][labelType]'] = "sent_message";
-        form['message_batch[0][creator_info][pageID]'] = ctx.globalOptions.pageId;
-        form['request_user_id'] = ctx.globalOptions.pageId;
-        form['message_batch[0][creator_info][profileURI]'] = "https://www.facebook.com/profile.php?id=" + ctx.userId;
-      }
+      api.uploadAttachment(msg.attachment, function (err, files) {
+        if (err) {
+          log.error("ERROR in sendMessage --> ", err);
+          return callback(err)
+        }
 
-      utils.post("https://www.facebook.com/ajax/mercury/send_messages.php", ctx.jar, form)
-      .then(utils.parseResponse)
-      .then(function(resData) {
-        if (!resData) return callback({error: "Send message failed."});
-        if(resData.error) return callback(resData);
+        files.forEach(function (file) {
+          var key = Object.keys(file);
+          var type = key[0]; // image_id, file_id, etc
 
-        callback();
-      })
-      .catch(function(err) {
-        log.error("ERROR in sendMessage --> ", err);
-        return callback(err);
+          form['message_batch[0][' + type + 's]'].push(file[type]); // push the id
+        });
+
+        send();
       });
-    });
+    } else {
+      send();
+    }
+
+    function send() {
+      // We're doing a query to this to check if the given id is the id of
+      // a user or of a group chat. The form will be different depending
+      // on that.
+      api.getUserInfo(thread_id, function(err, res) {
+        // This means that thread_id is the id of a user, and the chat
+        // is a single person chat
+        if(!(res instanceof Array)) {
+          form['message_batch[0][client_thread_id]'] = "user:"+thread_id;
+          form['message_batch[0][specific_to_list][0]'] = "fbid:"+thread_id;
+          form['message_batch[0][specific_to_list][1]'] = "fbid:"+ctx.userId;
+        }
+
+        if(ctx.globalOptions.pageId) {
+          form['message_batch[0][author]'] = "fbid:" + ctx.globalOptions.pageId;
+          form['message_batch[0][specific_to_list][1]'] = "fbid:" + ctx.globalOptions.pageId;
+          form['message_batch[0][creator_info][creatorID]'] = ctx.userId;
+          form['message_batch[0][creator_info][creatorType]'] = "direct_admin";
+          // form['message_batch[0][creator_info][creatorName]'] = Marc Zuckerbot
+          form['message_batch[0][creator_info][labelType]'] = "sent_message";
+          form['message_batch[0][creator_info][pageID]'] = ctx.globalOptions.pageId;
+          form['request_user_id'] = ctx.globalOptions.pageId;
+          form['message_batch[0][creator_info][profileURI]'] = "https://www.facebook.com/profile.php?id=" + ctx.userId;
+        }
+
+        utils.post("https://www.facebook.com/ajax/mercury/send_messages.php", ctx.jar, form)
+        .then(utils.parseResponse)
+        .then(function(resData) {
+          if (!resData) return callback({error: "Send message failed."});
+          if(resData.error) return callback(resData);
+
+          callback();
+        })
+        .catch(function(err) {
+          log.error("ERROR in sendMessage --> ", err);
+          return callback(err);
+        });
+      });
+    };
   };
 };

--- a/src/uploadAttachment.js
+++ b/src/uploadAttachment.js
@@ -1,0 +1,48 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+var bluebird = require("bluebird");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function sendAttachment(attachment, callback) {
+    function typeError() {
+      return callback({error: "Attachment should be of type array of readable stream and not " + typeof attachment + "."});
+    }
+
+    if (!(attachment instanceof Array)) return typeError();
+
+    var qs = mergeWithDefaults();
+    var uploads = []
+
+    // create an array of promises
+    for (var i = 0; i < attachment.length; i++) {
+      if (!utils.isReadableStream(attachment[i])) return typeError();
+
+      var form = {
+        upload_1024: attachment[i]
+      };
+
+      uploads.push(utils.postFormData("https://upload.facebook.com/ajax/mercury/upload.php", ctx.jar, form, qs)
+      .then(utils.parseResponse)
+      .then(function (resData) {
+        if (resData.error) {
+          throw resData
+        };
+
+        return resData.payload.metadata[0];
+      }));
+    }
+
+    // resolve all promises
+    bluebird.all(uploads)
+    .then(function(resData) {
+      callback(null, resData);
+    })
+    .catch(function(err) {
+      log.error("Error in sendAttachment", err);
+      return callback(err);
+    });
+  };
+};

--- a/src/uploadAttachment.js
+++ b/src/uploadAttachment.js
@@ -7,11 +7,13 @@ var bluebird = require("bluebird");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
   return function sendAttachment(attachment, callback) {
+    var attachmentType = utils.getType(attachment);
+
     function typeError() {
-      return callback({error: "Attachment should be of type array of readable stream and not " + typeof attachment + "."});
+      return callback({error: "Attachment should be of type array of readable stream and not " + attachmentType + "."});
     }
 
-    if (!(attachment instanceof Array)) return typeError();
+    if (attachmentType !== "Array") return typeError();
 
     var qs = mergeWithDefaults();
     var uploads = []

--- a/utils.js
+++ b/utils.js
@@ -268,8 +268,17 @@ function formatDate(date) {
     d+' '+ NUM_TO_MONTH[date.getUTCMonth()] +' '+ date.getUTCFullYear() +' '+
     h+':'+m+':'+s+' GMT';
 }
+
 function formatCookie(arr) {
   return arr[0]+"="+arr[1]+"; " + (arr[2] !== 0 ? "expires=" + formatDate(new Date(arr[2])) + "; " : "") + "path=" + arr[3] + ";";
+}
+
+function getType(obj) {
+  return Object.prototype.toString.call(obj).slice(8, -1);
+}
+
+function checkType(obj, type) {
+  return getType(obj) === type;
 }
 
 module.exports = {
@@ -290,5 +299,7 @@ module.exports = {
   formatEvent: formatEvent,
   parseResponse: parseResponse,
   saveCookies: saveCookies,
-  formatCookie: formatCookie
+  formatCookie: formatCookie,
+  getType: getType,
+  checkType: checkType
 };

--- a/utils.js
+++ b/utils.js
@@ -277,10 +277,6 @@ function getType(obj) {
   return Object.prototype.toString.call(obj).slice(8, -1);
 }
 
-function checkType(obj, type) {
-  return getType(obj) === type;
-}
-
 module.exports = {
   isReadableStream: isReadableStream,
   get: get,
@@ -300,6 +296,5 @@ module.exports = {
   parseResponse: parseResponse,
   saveCookies: saveCookies,
   formatCookie: formatCookie,
-  getType: getType,
-  checkType: checkType
+  getType: getType
 };


### PR DESCRIPTION
This should solve #43 

It's a little different than @Schmavery has had envisioned. Instead of using different function to allow attachment upload, i'll be using ```api.sendMessage``` by passing an object containing the **body** (string) and **attachment** (readable stream or an array of readable stream). I think this is much simpler.

```
var msg = {
  body: 'message body',
  attachment: fs.createReadStream(__dirname + '/image.jpg')
}

api.sendMessage(msg, message.thread_id)
```

```api.sendMessage``` will still support passing string in the first argument, so the current example in the documentation still works.

As for the ```api.uploadAttachment```,
it's a function to *upload* the attachment, it will return the attachment id to be passed in the message form. The ```api.sendMessage``` will invoke this first before sending the message, if the new message contain an attachment.

i'd recommend making ```api.sendSticker``` like this too. Since the form data is similar, you should avoid repeating yourself.