### PR TITLE
Adding deleteMessage, deleteThread, archiveThread, and unarchiveThread endpoints.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,11 @@ function _login(email, password, loginOptions, callback) {
         'addUserToGroup',
         'sendTypingIndicator',
         'getCurrentUserId',
-        'uploadAttachment'];
+        'uploadAttachment',
+        'deleteMessage',
+        'deleteThread',
+        'archiveThread',
+        'unarchiveThread'];
 
       var mergeWithDefaults = utils.makeMergeWithDefaults(html, userId);
 

--- a/src/archiveThread.js
+++ b/src/archiveThread.js
@@ -5,10 +5,17 @@ var utils = require("../utils");
 var log = require("npmlog");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
-  return function archiveThread(thread_id, callback) {
+  return function archiveThread(threadOrThreads, callback) {
 
     var form = mergeWithDefaults();
-    form['ids['+thread_id+']'] = true;
+
+    if(Array.isArray(threadOrThreads)) {
+      for (var i = 0; i < threadOrThreads.length; i++) {
+        form['ids['+threadOrThreads[i]+']'] = true;
+      }
+    } else {
+      form['ids['+threadOrThreads+']'] = true;
+    }
 
     utils.post("https://www.facebook.com/ajax/mercury/change_archived_status.php", ctx.jar, form)
       .then(utils.parseResponse)

--- a/src/archiveThread.js
+++ b/src/archiveThread.js
@@ -1,0 +1,26 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function archiveThread(thread_id, callback) {
+
+    var form = mergeWithDefaults();
+    form['ids['+thread_id+']'] = true;
+
+    utils.post("https://www.facebook.com/ajax/mercury/change_archived_status.php", ctx.jar, form)
+      .then(utils.parseResponse)
+      .then(function(resData) {
+        if (resData.error) {
+          callback(resData);
+        } else callback(null);
+      })
+      .catch(function(err) {
+        log.error("Error in archiveThread", err);
+        return callback(err);
+      });
+    return ctx.access_token;
+  };
+};

--- a/src/deleteMessage.js
+++ b/src/deleteMessage.js
@@ -6,7 +6,11 @@ var log = require("npmlog");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
   return function deleteMessage(messageOrMessages, callback) {
-    var message_id = message.message_id || message;
+    // this allows also passing a message object
+    var message_id = messageOrMessages.message_id || null;
+    if(message_id != null) {
+      messageOrMessages = message_id;
+    }
 
     var form = mergeWithDefaults();
     form['client'] = "mercury";
@@ -18,7 +22,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
     } else {
       form['message_ids[0]'] = messageOrMessages;
     }
-    
+
     utils.post("https://www.facebook.com/ajax/mercury/delete_messages.php", ctx.jar, form)
       .then(utils.parseResponse)
       .then(function(resData) {

--- a/src/deleteMessage.js
+++ b/src/deleteMessage.js
@@ -5,14 +5,20 @@ var utils = require("../utils");
 var log = require("npmlog");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
-  return function deleteMessage(message, callback) {
+  return function deleteMessage(messageOrMessages, callback) {
     var message_id = message.message_id || message;
-    
-    var form = mergeWithDefaults({
-      'client' : 'mercury',
-      'message_ids[0]' : message_id
-    });
 
+    var form = mergeWithDefaults();
+    form['client'] = "mercury";
+
+    if(Array.isArray(messageOrMessages)) {
+      for (var i = 0; i < messageOrMessages.length; i++) {
+        form['message_ids['+i+']'] = messageOrMessages[i];
+      }
+    } else {
+      form['message_ids[0]'] = messageOrMessages;
+    }
+    
     utils.post("https://www.facebook.com/ajax/mercury/delete_messages.php", ctx.jar, form)
       .then(utils.parseResponse)
       .then(function(resData) {

--- a/src/deleteMessage.js
+++ b/src/deleteMessage.js
@@ -1,0 +1,29 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function deleteMessage(message, callback) {
+    var message_id = message.message_id || message;
+    
+    var form = mergeWithDefaults({
+      'client' : 'mercury',
+      'message_ids[0]' : message_id
+    });
+
+    utils.post("https://www.facebook.com/ajax/mercury/delete_messages.php", ctx.jar, form)
+      .then(utils.parseResponse)
+      .then(function(resData) {
+        if (resData.error) {
+          callback(resData);
+        } else callback(null);
+      })
+      .catch(function(err) {
+        log.error("Error in deleteMessage", err);
+        return callback(err);
+      });
+    return ctx.access_token;
+  };
+};

--- a/src/deleteThread.js
+++ b/src/deleteThread.js
@@ -1,0 +1,28 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function deleteThread(thread_id, callback) {
+
+    var form = mergeWithDefaults({
+      'client' : 'mercury',
+      'ids[0]' : thread_id
+    });
+
+    utils.post("https://www.facebook.com/ajax/mercury/delete_thread.php", ctx.jar, form)
+      .then(utils.parseResponse)
+      .then(function(resData) {
+        if (resData.error) {
+          callback(resData);
+        } else callback(null);
+      })
+      .catch(function(err) {
+        log.error("Error in deleteThread", err);
+        return callback(err);
+      });
+    return ctx.access_token;
+  };
+};

--- a/src/deleteThread.js
+++ b/src/deleteThread.js
@@ -5,12 +5,18 @@ var utils = require("../utils");
 var log = require("npmlog");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
-  return function deleteThread(thread_id, callback) {
+  return function deleteThread(threadOrThreads, callback) {
 
-    var form = mergeWithDefaults({
-      'client' : 'mercury',
-      'ids[0]' : thread_id
-    });
+    var form = mergeWithDefaults();
+    form['client'] = 'mercury';
+
+    if(Array.isArray(threadOrThreads)) {
+      for (var i = 0; i < threadOrThreads.length; i++) {
+        form['ids['+i+']'] = threadOrThreads[i];
+      }
+    } else {
+      form['ids[0]'] = threadOrThreads;
+    }
 
     utils.post("https://www.facebook.com/ajax/mercury/delete_thread.php", ctx.jar, form)
       .then(utils.parseResponse)

--- a/src/listen.js
+++ b/src/listen.js
@@ -103,7 +103,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
               if(v.event !== "deliver") return;
               if(!ctx.globalOptions.selfListen && v.message.sender_fbid.toString() === ctx.userId.toString()) return;
               atLeastOne = true;
-              callback(null, utils.attachMessageFunctions(utils.formatMessage(v), api), stopListening);
+              callback(null, utils.formatMessage(v), stopListening);
             case 'pages_messaging':
               if(!ctx.globalOptions.pageId) return;
               if(v.event !== "deliver") return;
@@ -111,7 +111,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
               if(v.realtime_viewer_fbid !== ctx.globalOptions.pageId) return;
 
               atLeastOne = true;
-              callback(null, utils.attachMessageFunctions(utils.formatMessage(v), api), stopListening);
+              callback(null, utils.formatMessage(v), stopListening);
               break;
           }
         });

--- a/src/listen.js
+++ b/src/listen.js
@@ -103,7 +103,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
               if(v.event !== "deliver") return;
               if(!ctx.globalOptions.selfListen && v.message.sender_fbid.toString() === ctx.userId.toString()) return;
               atLeastOne = true;
-              callback(null, utils.formatMessage(v), stopListening);
+              callback(null, utils.attachMessageFunctions(utils.formatMessage(v), api), stopListening);
             case 'pages_messaging':
               if(!ctx.globalOptions.pageId) return;
               if(v.event !== "deliver") return;
@@ -111,7 +111,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
               if(v.realtime_viewer_fbid !== ctx.globalOptions.pageId) return;
 
               atLeastOne = true;
-              callback(null, utils.formatMessage(v), stopListening);
+              callback(null, utils.attachMessageFunctions(utils.formatMessage(v), api), stopListening);
               break;
           }
         });

--- a/src/unarchiveThread.js
+++ b/src/unarchiveThread.js
@@ -5,11 +5,18 @@ var utils = require("../utils");
 var log = require("npmlog");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
-  return function unarchiveThread(thread_id, callback) {
+  return function unarchiveThread(threadOrThreads, callback) {
 
     var form = mergeWithDefaults();
-    form['ids['+thread_id+']'] = false;
 
+    if(Array.isArray(threadOrThreads)) {
+      for (var i = 0; i < threadOrThreads.length; i++) {
+        form['ids['+threadOrThreads[i]+']'] = false;
+      }
+    } else {
+      form['ids['+threadOrThreads+']'] = false;
+    }
+    
     utils.post("https://www.facebook.com/ajax/mercury/change_archived_status.php", ctx.jar, form)
       .then(utils.parseResponse)
       .then(function(resData) {

--- a/src/unarchiveThread.js
+++ b/src/unarchiveThread.js
@@ -1,0 +1,26 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function unarchiveThread(thread_id, callback) {
+
+    var form = mergeWithDefaults();
+    form['ids['+thread_id+']'] = false;
+
+    utils.post("https://www.facebook.com/ajax/mercury/change_archived_status.php", ctx.jar, form)
+      .then(utils.parseResponse)
+      .then(function(resData) {
+        if (resData.error) {
+          callback(resData);
+        } else callback(null);
+      })
+      .catch(function(err) {
+        log.error("Error in unarchiveThread", err);
+        return callback(err);
+      });
+    return ctx.access_token;
+  };
+};

--- a/utils.js
+++ b/utils.js
@@ -118,7 +118,8 @@ function formatMessage(m) {
     participant_ids: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_ids : [originalMessage.sender_fbid]),
     body: originalMessage.body,
     thread_id: originalMessage.tid && originalMessage.tid.split(".")[0] === "id" ? originalMessage.tid.split('.')[1] : originalMessage.other_user_fbid,
-    location: originalMessage.coordinates ? originalMessage.coordinates : null
+    location: originalMessage.coordinates ? originalMessage.coordinates : null,
+    message_id: originalMessage.mid
   };
 
   if (originalMessage.attachments){

--- a/utils.js
+++ b/utils.js
@@ -239,6 +239,10 @@ function makeMergeWithDefaults(html, userId) {
 }
 
 function parseResponse(res) {
+  // functions don't play nicely here, get rid of them
+  delete res.delete;
+  delete res.archiveThread;
+
   return bluebird.try(function() {
     return JSON.parse(makeParsable(res.body));
   });
@@ -278,6 +282,21 @@ function getType(obj) {
   return Object.prototype.toString.call(obj).slice(8, -1);
 }
 
+function attachMessageFunctions(message, api) {
+  // if adding a function here remember to
+  // delete it in parseResponse()
+  message.delete = function(callback) {
+    api.deleteMessage(message.message_id, callback)
+  };
+
+  message.archiveThread = function(callback) {
+    api.archiveThread(message.thread_id, callback)
+  };
+
+  return message;
+
+}
+
 module.exports = {
   isReadableStream: isReadableStream,
   get: get,
@@ -297,5 +316,6 @@ module.exports = {
   parseResponse: parseResponse,
   saveCookies: saveCookies,
   formatCookie: formatCookie,
-  getType: getType
+  getType: getType,
+  attachMessageFunctions: attachMessageFunctions
 };

--- a/utils.js
+++ b/utils.js
@@ -239,10 +239,6 @@ function makeMergeWithDefaults(html, userId) {
 }
 
 function parseResponse(res) {
-  // functions don't play nicely here, get rid of them
-  delete res.delete;
-  delete res.archiveThread;
-
   return bluebird.try(function() {
     return JSON.parse(makeParsable(res.body));
   });
@@ -282,21 +278,6 @@ function getType(obj) {
   return Object.prototype.toString.call(obj).slice(8, -1);
 }
 
-function attachMessageFunctions(message, api) {
-  // if adding a function here remember to
-  // delete it in parseResponse()
-  message.delete = function(callback) {
-    api.deleteMessage(message.message_id, callback)
-  };
-
-  message.archiveThread = function(callback) {
-    api.archiveThread(message.thread_id, callback)
-  };
-
-  return message;
-
-}
-
 module.exports = {
   isReadableStream: isReadableStream,
   get: get,
@@ -316,6 +297,5 @@ module.exports = {
   parseResponse: parseResponse,
   saveCookies: saveCookies,
   formatCookie: formatCookie,
-  getType: getType,
-  attachMessageFunctions: attachMessageFunctions
+  getType: getType
 };


### PR DESCRIPTION
This also adds message_id (mid) to message objects.

In my current project I required being able to run these methods (particularly deleteMessage and archiveThread).

Usage is fairly simple:

**deleteMessage**

    api.deleteMessage(message.message_id, function(err) {
      if(err) { 
        console.log('Error while deleting message..');
      } 
    });

**deleteThread**

    api.deleteThread(message.thread_id, function(err) {
      if(err) { 
        console.log('Error while deleting a thread..');
      } 
    });

**archiveThread**

    api.archiveThread(message.thread_id, function(err) {
      if(err) { 
        console.log('Error while archiving a thread..');
      } 
    });

**unarchiveThread**

    api.deleteMessage(thread_to_unarchive, function(err) {
      if(err) { 
        console.log('Error while unarchiving a thread..');
      } 
    });

