### PR TITLE
getMessages (retrieve list of messages from thread)

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ function _login(email, password, loginOptions, callback) {
         'sendDirectSticker',
         'sendSticker',
         'setTitle',
+        'getMessages',
         'getThreadList',
         'markAsRead',
         'sendMessage',

--- a/src/getMessages.js
+++ b/src/getMessages.js
@@ -1,0 +1,40 @@
+/*jslint node: true */
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(mergeWithDefaults, api, ctx) {
+  return function getMessages(thread_id, start, end, callback) {
+    if(!callback) callback = function() {};
+
+    if (end <= start) end = start + 20;
+
+    var startKey = 'messages[user_ids][' + thread_id + '][offset]';
+    var endKey = 'messages[user_ids][' + thread_id + '][limit]';
+
+    var form = mergeWithDefaults({
+      'client' : 'mercury',
+      startKey : start,
+      endKey : end
+    });
+
+    if(ctx.globalOptions.pageId) form.request_user_id = ctx.globalOptions.pageId;
+
+    utils.post("https://www.facebook.com/ajax/mercury/thread_info.php", ctx.jar, form)
+    .then(utils.parseResponse)
+    .then(function(resData) {
+      if (resData.error && resData.error === 1545012){
+        callback({error: "Cannot change chat title: Not member of chat."});
+      } else if (resData.error && resData.error === 1545003){
+        callback({error: "Cannot set title of single-user chat."});
+      } else if (resData.error) {
+        callback(resData);
+      } else callback(null, resData.payload.threads);
+    })
+    .catch(function(err) {
+      log.error("Error in getMessages", err);
+      return callback(err);
+    });
+  };
+};

--- a/src/getMessages.js
+++ b/src/getMessages.js
@@ -5,19 +5,21 @@ var utils = require("../utils");
 var log = require("npmlog");
 
 module.exports = function(mergeWithDefaults, api, ctx) {
-  return function getMessages(thread_id, start, end, callback) {
+  return function getMessages(threadId, isGroup, start, end, callback) {
     if(!callback) callback = function() {};
 
     if (end <= start) end = start + 20;
 
-    var startKey = 'messages[user_ids][' + thread_id + '][offset]';
-    var endKey = 'messages[user_ids][' + thread_id + '][limit]';
+    var ids = isGroup ? 'thread_fbids' : 'user_ids';
 
-    var form = mergeWithDefaults({
-      'client' : 'mercury',
-      startKey : start,
-      endKey : end
-    });
+    var startKey = 'messages[' + ids + '][' + threadId + '][offset]';
+    var endKey = 'messages[' + ids + '][' + threadId + '][limit]';
+
+    var toMerge = {};
+    toMerge[startKey] = start;
+    toMerge[endKey] = end;
+
+    var form = mergeWithDefaults(toMerge);
 
     if(ctx.globalOptions.pageId) form.request_user_id = ctx.globalOptions.pageId;
 
@@ -30,7 +32,7 @@ module.exports = function(mergeWithDefaults, api, ctx) {
         callback({error: "Cannot set title of single-user chat."});
       } else if (resData.error) {
         callback(resData);
-      } else callback(null, resData.payload.threads);
+      } else callback(null, resData.payload.actions);
     })
     .catch(function(err) {
       log.error("Error in getMessages", err);


### PR DESCRIPTION
I'm creating an app for Facebook messages and needed to retrieve the existing messages from a thread. I copied "getThreadList.js" and modified it for "thread_info.php". I don't know what errors this endpoint will return, so I left the error checking as-is. Please make sure this meets your standards and I would love to see it added!