### PR TITLE
Include timestamp in formatMessage

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -251,6 +251,10 @@ function formatMessage(m) {
     location: originalMessage.coordinates ? originalMessage.coordinates : null,
     messageID: originalMessage.mid,
     attachments: formatAttachment(originalMessage.attachments, originalMessage.attachmentIds, originalMessage.attachment_map, originalMessage.share_map),
+    timestamp: originalMessage.timestamp,
+    timestampAbsolute: originalMessage.timestamp_absolute,
+    timestampRelative: originalMessage.timestamp_relative,
+    timestampDatetime: originalMessage.timestamp_datetime,
   };
 
   if(m.type === "pages_messaging") obj.pageID = m.realtime_viewer_fbid;


### PR DESCRIPTION
Timestamp used to be included pre 1.0. I'm migrating to the new version and noticed timestamp was missing.