### PR TITLE
Limit thread query from 1 --> 21

### DIFF
--- a/src/searchForThread.js
+++ b/src/searchForThread.js
@@ -12,7 +12,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       client: 'web_messenger',
       query: name,
       offset: 0,
-      limit: 1,
+      limit: 21,
       index: 'fbid',
     };
 


### PR DESCRIPTION
See the following image:
![image](https://cloud.githubusercontent.com/assets/5896658/10120294/fa499bec-6479-11e5-927b-9c3253ca5318.png)
The Facebook API uses limit: 21 when it hits search_threads.php. Unless it was intentional to only search for a single thread, I think it was a typo.