### PR TITLE
Account for undefined attachments in formatAttachment

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -242,13 +242,13 @@ function _formatAttachment(attachment1, attachment2) {
 
 function formatAttachment(attachments, attachmentIds, attachmentMap, shareMap) {
   attachmentMap = shareMap || attachmentMap;
-  return attachments.map(function(val, i) {
+  return attachments ? attachments.map(function(val, i) {
     // TODO: THIS IS REALLY BAD
     if (!attachmentMap || !attachmentIds){
       return _formatAttachment(val, {id:"", image_data: {}});
     }
     return _formatAttachment(val, attachmentMap[attachmentIds[i]]);
-  });
+  }) : [];
 }
 
 function formatMessage(m) {


### PR DESCRIPTION
I was trying to load some old conversations and received an error saying could not access `map` of `undefined`. I think Facebook used to pass an undefined array in `attachments`, and this small change accounts for that.