### PR TITLE
Return timestamp in sendMessage

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -432,7 +432,7 @@ __Arguments__
 
 * `message`: A string (for backward compatibility) or a message object as described below.
 * `threadID`: A string, number, or array representing a thread. It happens to be someone's userId in the case of a one to one conversation or an array of userIds when starting a new group chat.
-* `callback(err, messageInfo)`: A callback called when sending the message is done (either with an error or with an confirmation object). `messageInfo` contains the `threadID` where the message was sent and a `messageID`.
+* `callback(err, messageInfo)`: A callback called when sending the message is done (either with an error or with an confirmation object). `messageInfo` contains the `threadID` where the message was sent and a `messageID`, as well as the `timestamp` of the message.
 
 __Message Object__: 
 

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -191,7 +191,8 @@ module.exports = function(defaultFuncs, api, ctx) {
           var messageInfo = resData.payload.actions.reduce(function(p, v) {
             return {
               threadID: v.thread_fbid,
-              messageID: v.message_id
+              messageID: v.message_id,
+              timestamp: v.timestamp
             } || p; }, null);
 
           return callback(null, messageInfo);


### PR DESCRIPTION
Send back Facebook's message timestamp in the sendMessage endpoint.

I think this is necessary because Facebook's timestamps are different than my local machines'. For example, when I receive a message (with `listen()`), my Date.now() is 15 seconds off from the message's timestamp that I received from Facebook. This causes issues when users send/receive messages in a short amount of time. Using Facebook's timestamps everywhere should resolve the timestamp discrepancies I'm seeing.

Side note: is there a reason the whole message object isn't sent back?