### PR TITLE
Fix internal link to api.getThreadHistory

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -8,7 +8,7 @@
 * [`api.getCurrentUserID`](#getCurrentUserID)
 * [`api.getFriendsList`](#getFriendsList)
 * [`api.getOnlineUsers`](#getOnlineUsers)
-* [`api.getThreadHistory`](#searchForThread)
+* [`api.getThreadHistory`](#getThreadHistory)
 * [`api.getThreadList`](#getThreadList)
 * [`api.deleteThread`](#deleteThread)
 * [`api.getUserID`](#getUserID)


### PR DESCRIPTION
The link in the docs currently jumps to searchForThread.