### PR TITLE
Fix type inconsistency in read_receipt event

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -300,9 +300,9 @@ function formatTyp(event) {
 
 function formatReadReceipt(event) {
   return {
-    reader: event.reader,
+    reader: event.reader.toString(),
     time: event.time,
-    threadID: event.realtime_viewer_fbid,
+    threadID: event.realtime_viewer_fbid.toString(),
     type: 'read_receipt',
   };
 }


### PR DESCRIPTION
``reader`` and ``threadID`` in all events is always string, except for read_receipt.

Also, i want to ask, why is the key which contain the sender id is different in every event? (senderID, author, from, reader)
