### PR TITLE
Fix: change pageId to pageID on DOCS.md

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -554,7 +554,7 @@ __Arguments__
       caution, as it can result in loops (a simple echo bot will send messages
       forever).
     - `listenEvents`: (Default `false`) Will make [api.listen](#listen) also handle events (look at api.listen for more details).
-    - `pageId`: (Default empty) Makes [api.listen](#listen) only receive messages through the page specified by that ID. Also makes `sendMessage` and `sendSticker` send from the page.
+    - `pageID`: (Default empty) Makes [api.listen](#listen) only receive messages through the page specified by that ID. Also makes `sendMessage` and `sendSticker` send from the page.
     - `updatePresence`: (Default `false`) Will make [api.listen](#listen) also return `presence` ([api.listen](#presence) for more details).
     - `forceLogin`: (Default `false`) Will automatically approve of any recent logins and continue with the login process.
 


### PR DESCRIPTION
If login function is used with {pageId: 'xxx'}, it raises a Warning:
WARN Unrecognized option given to setOptions pageId.

Changing to pageID fixes the problem