### PR TITLE
Use more stable lookup method for logout element filter

### DIFF
--- a/src/logout.js
+++ b/src/logout.js
@@ -16,7 +16,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       .then(utils.parseAndCheckLogin)
       .then(function(resData) {
         var elem = resData.jsmods.instances[0][2][0].filter(function(v) {
-          return v.label === "Log Out";
+          return v.value === "logout";
         })[0];
 
         var html = resData.jsmods.markup.filter(function(v) {


### PR DESCRIPTION
Fixes #126 

Considering the tests were already catching this regression (see below), I saw no need to modify them. I'm still unsure as to why I receive an element with `label` of `Log out` and others receive `Log Out`. At first I considered facebook could be sending different content based on country (I'm in Canada), but that turned out not to be the case.

```
> facebook-chat-api@1.0.4 test /Users/andyjbas/code/facebook-chat-api
> mocha



  Login:

    1) should log out


  0 passing (6s)
  1 failing

  1) Login: should log out:
     TypeError: Cannot read property 'markup' of undefined
      at src/logout.js:24:31
      at Array.filter (native)
      at src/logout.js:23:42
      at tryCatcher (node_modules/bluebird/js/main/util.js:26:23)
      at Promise._settlePromiseFromHandler (node_modules/bluebird/js/main/promise.js:507:31)
      at Promise._settlePromiseAt (node_modules/bluebird/js/main/promise.js:581:18)
      at Promise._settlePromises (node_modules/bluebird/js/main/promise.js:697:14)
      at Async._drainQueue (node_modules/bluebird/js/main/async.js:123:16)
      at Async._drainQueues (node_modules/bluebird/js/main/async.js:133:10)
      at Immediate.Async.drainQueues [as _onImmediate] (node_modules/bluebird/js/main/async.js:15:14)
```

I have a quick q about error handling - what is the use case for [throwing non error objects](https://github.com/Schmavery/facebook-chat-api/blob/master/src/logout.js#L38) over explicitly creating a new `Error`? The first downside that I noticed was that the mocha `done` callback will always complain when passed a non error, but also clients will not be receiving consistent `err` values in their callbacks. For example, when this `TypeError`, as shown above, is thrown, the client will get an `Error`, but in a case like [this](https://github.com/Schmavery/facebook-chat-api/blob/master/src/logout.js#L38) they will get an object.