### PR TITLE
Include offline users in getOnlineUsers (as offline)

### DIFF
--- a/src/getOnlineUsers.js
+++ b/src/getOnlineUsers.js
@@ -10,12 +10,16 @@ var STATUS = {
   3: 'mobile',
 };
 
-function formatData(data, lastActiveTimes, time) {
-  return Object.keys(data).map(function(key) {
+function formatData(availableList, lastActiveTimes, time) {
+  return Object.keys(lastActiveTimes).map(function(key) {
+    var status = STATUS[0]; // offline
+    if(key in availableList) {
+      status = STATUS[availableList[key].a];
+    }
     return {
       lastActive: (lastActiveTimes[key] * 1000) || time,
       userID: key,
-      status: STATUS[data[key].a],
+      status: status,
     };
   });
 }


### PR DESCRIPTION
Previously all users returned from this API had to be online, as it used the nowAvailableList as the lookup. 
This change instead uses the last_active_times list as the lookup, and any person not found in the nowAvailableList is by-default 'offline'.

The offline status field was always included in the response, so I think this change shouldn't cause any problems unless people were always relying that the users were online instead of checking that field. If that's the case, then I guess this is somewhat of a breaking change...

I only want this to get the last active time - getFriendsList would be a better place for that, but I presume that the data is not included in that response.