### PR TITLE
fixed deleting body on sticker presence

### DIFF
--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -142,8 +142,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       form['message_batch[0][sticker_id]'] = msg.sticker;
 
       // Sticker can't be combined with body
-      delete msg.body;
-
+      delete form['message_batch[0][body]']
       send();
     } else {
       send();


### PR DESCRIPTION
The body doesn't get deleted when a message has a sticker.
Deleted body from `form` object rather than `msg` object.