### PR TITLE
Patch bug of non working messenger scripts when logining from AppState

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,6 +273,11 @@ function loginHelper(appState, email, password, globalOptions, callback) {
     appState.map(function(c) {
       var str = c.key + "=" + c.value + "; expires=" + c.expires + "; domain=" + c.domain + "; path=" + c.path + ";";
       jar.setCookie(str, "http://" + c.domain);
+			if(c.domain.indexOf("facebook.com") > -1)
+			{
+				str = c.key + "=" + c.value + "; expires=" + c.expires + "; domain=messenger.com; path=" + c.path + ";";
+				jar.setCookie(str, "http://messenger.com");
+			}
     });
 
     // Load the main page.


### PR DESCRIPTION
Okay, so in Messenger.com works same cookies in Facebook.com .
Change color and emoji dont work for me because when is user logged via AppState, in AppState isnt a Messenger.com cookies and its not added after login, so I added that!

But I dont think this is a good idea to fix this problem! I think it will be better to roll back the changes of saving a messenger.com cookies, and only create function "makeMessengerCookies" for scripts what requesting to messenger.com.