### PR TITLE
Remove extraneous and invalid main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "facebook-chat-api",
   "version": "1.0.8",
   "description": "Facebook chat API that doesn't rely on XMPP.  Will NOT be deprecated April 30th 2015.",
-  "main": "server.js",
   "scripts": {
     "test": "node_modules/.bin/mocha",
     "start": "node server.js"


### PR DESCRIPTION
In node, `require('facebook-chat-api')` will try and load `server.js` (and fail), then fallback to `index.js`.
This is fine if you're using node, but I'm using [jspm](http://jspm.io/) which isn't too happy and errors with 'unable to find server.js'. Yes, this could be fixed on jspm's end, but it still leaves the unknown server.js reference in this package which might cause problems for other package managers (and even npm/node in the future?), so it'd be best to fix it here.