### PR TITLE
Update NPM package for getThreadInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-chat-api",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Facebook chat API that doesn't rely on XMPP.  Will NOT be deprecated April 30th 2015.",
   "scripts": {
     "test": "node_modules/.bin/mocha",


### PR DESCRIPTION
I was wondering why getThreadInfo wasn't working and after checking out the repo it looks like it's because it's a recently added feature that hasn't been published to NPM yet. I've updated the version number to reflect the changes (minor update since features were added). Just run `npm publish` and you should be good!

(I'm not sure if you were purposely holding out on publishing or not - if so, I can always just find another way to get thread information)