### PR TITLE
Added customTagNames to formatThread

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -370,7 +370,7 @@ __Arguments__
 * `start`: Start index in the list of recently used threads.
 * `end`: End index.
 * `type`: Optional String, can be 'inbox', 'pending', or 'archived'. Inbox is default.
-* `callback(err, arr)`: A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of thread object containing the following properties: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID`.
+* `callback(err, arr)`: A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of thread object containing the following properties: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID`, `customTagNames`.
 
 ---------------------------------------
 

--- a/utils.js
+++ b/utils.js
@@ -632,7 +632,8 @@ function formatThread(data) {
     canReply: data.can_reply,
     composerEnabled: data.composer_enabled,
     blockedParticipants: data.blocked_participants,
-    lastMessageID: data.last_message_id
+    lastMessageID: data.last_message_id,
+    customTagNames: data.page_thread_info.customTagNames
   };
 }
 

--- a/utils.js
+++ b/utils.js
@@ -633,7 +633,7 @@ function formatThread(data) {
     composerEnabled: data.composer_enabled,
     blockedParticipants: data.blocked_participants,
     lastMessageID: data.last_message_id,
-    customTagNames: data.page_thread_info.customTagNames
+    customTagNames: typeof data.page_thread_info != 'undefined' ? data.page_thread_info.customTagNames : undefined
   };
 }
 


### PR DESCRIPTION
I need to retrieve the tags of the threads, thus added this to formatThread() in utils.js. 
