### PR TITLE
Adding tags to formatMessage()

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -381,6 +381,7 @@ function formatMessage(m) {
     timestampAbsolute: originalMessage.timestamp_absolute,
     timestampRelative: originalMessage.timestamp_relative,
     timestampDatetime: originalMessage.timestamp_datetime,
+    tags: originalMessage.tags 
   };
 
   if(m.type === "pages_messaging") obj.pageID = m.realtime_viewer_fbid.toString();


### PR DESCRIPTION
The message objects have a member called 'tags'. The value of this member is an array.
Example:
`"tags": ["pages_comm_instant_reply","cg-enabled","sent","source:titan:web","inbox"]`
Example use case: For me, the "pages_comm_instant_reply" tag is important to identify, as this shows that the message is an Instant Reply:
https://www.facebook.com/help/1615627532020480

Tested on user threads and page threads.
