### PR TITLE
update to improve compatibility with new api

### DIFF
--- a/src/addUserToGroup.js
+++ b/src/addUserToGroup.js
@@ -24,29 +24,29 @@ module.exports = function(defaultFuncs, api, ctx) {
     var messageAndOTID = utils.generateOfflineThreadingID();
     var form = {
       'client' : 'mercury',
-      'message_batch[0][action_type]' : 'ma-type:log-message',
-      'message_batch[0][author]' : 'fbid:' + ctx.userID,
-      'message_batch[0][thread_id]' : '',
-      'message_batch[0][timestamp]' : Date.now(),
-      'message_batch[0][timestamp_absolute]' : 'Today',
-      'message_batch[0][timestamp_relative]' : utils.generateTimestampRelative(),
-      'message_batch[0][timestamp_time_passed]' : '0',
-      'message_batch[0][is_unread]' : false,
-      'message_batch[0][is_cleared]' : false,
-      'message_batch[0][is_forward]' : false,
-      'message_batch[0][is_filtered_content]' : false,
-      'message_batch[0][is_filtered_content_bh]':false,
-      'message_batch[0][is_filtered_content_account]':false,
-      'message_batch[0][is_spoof_warning]' : false,
-      'message_batch[0][source]' : 'source:chat:web',
-      'message_batch[0][source_tags][0]' : 'source:chat',
-      'message_batch[0][log_message_type]' : 'log:subscribe',
-      'message_batch[0][status]' : '0',
-      'message_batch[0][offline_threading_id]' : messageAndOTID,
-      'message_batch[0][message_id]' : messageAndOTID,
-      'message_batch[0][threading_id]': utils.generateThreadingID(ctx.clientID),
-      'message_batch[0][manual_retry_cnt]' : '0',
-      'message_batch[0][thread_fbid]' : threadID,
+      'action_type' : 'ma-type:log-message',
+      'author' : 'fbid:' + ctx.userID,
+      'thread_id' : '',
+      'timestamp' : Date.now(),
+      'timestamp_absolute' : 'Today',
+      'timestamp_relative' : utils.generateTimestampRelative(),
+      'timestamp_time_passed' : '0',
+      'is_unread' : false,
+      'is_cleared' : false,
+      'is_forward' : false,
+      'is_filtered_content' : false,
+      'is_filtered_content_bh':false,
+      'is_filtered_content_account':false,
+      'is_spoof_warning' : false,
+      'source' : 'source:chat:web',
+      'source_tags[0]' : 'source:chat',
+      'log_message_type' : 'log:subscribe',
+      'status' : '0',
+      'offline_threading_id' : messageAndOTID,
+      'message_id' : messageAndOTID,
+      'threading_id': utils.generateThreadingID(ctx.clientID),
+      'manual_retry_cnt' : '0',
+      'thread_fbid' : threadID,
     };
 
     for (var i = 0; i < userID.length; i++){
@@ -54,10 +54,10 @@ module.exports = function(defaultFuncs, api, ctx) {
         throw {error: "Elements of userID should be of type Number or String and not " + utils.getType(userID[i]) + "."};
       }
 
-      form['message_batch[0][log_message_data][added_participants]['+i+']'] = 'fbid:' + userID[i];
+      form['log_message_data[added_participants]['+i+']'] = 'fbid:' + userID[i];
     }
 
-    defaultFuncs.post("https://www.facebook.com/ajax/mercury/send_messages.php", ctx.jar, form)
+    defaultFuncs.post("https://www.facebook.com/messaging/send/", ctx.jar, form)
     .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
     .then(function(resData) {
       if (!resData) {

--- a/src/changeGroupImage.js
+++ b/src/changeGroupImage.js
@@ -48,31 +48,31 @@ module.exports = function(defaultFuncs, api, ctx) {
     var messageAndOTID = utils.generateOfflineThreadingID();
     var form = {
       'client' : 'mercury',
-      'message_batch[0][action_type]' : 'ma-type:log-message',
-      'message_batch[0][author]' : 'fbid:' + ctx.userID,
-      'message_batch[0][author_email]' : '',
-      'message_batch[0][ephemeral_ttl_mode]' : '0',
-      'message_batch[0][is_filtered_content]' : false,
-      'message_batch[0][is_filtered_content_account]' : false,
-      'message_batch[0][is_filtered_content_bh]' : false,
-      'message_batch[0][is_filtered_content_invalid_app]' : false,
-      'message_batch[0][is_filtered_content_quasar]' : false,
-      'message_batch[0][is_forward]' : false,
-      'message_batch[0][is_spoof_warning]' : false,
-      'message_batch[0][is_unread]' : false,
-      'message_batch[0][log_message_type]' : 'log:thread-image',
-      'message_batch[0][manual_retry_cnt]' : '0',
-      'message_batch[0][message_id]' : messageAndOTID,
-      'message_batch[0][offline_threading_id]' : messageAndOTID,
-      'message_batch[0][source]' : 'source:chat:web',
-      'message_batch[0][source_tags][0]' : 'source:chat',
-      'message_batch[0][status]' : '0',
-      'message_batch[0][thread_fbid]' : threadID,
-      'message_batch[0][thread_id]' : '',
-      'message_batch[0][timestamp]' : Date.now(),
-      'message_batch[0][timestamp_absolute]' : 'Today',
-      'message_batch[0][timestamp_relative]' : utils.generateTimestampRelative(),
-      'message_batch[0][timestamp_time_passed]' : '0',
+      'action_type' : 'ma-type:log-message',
+      'author' : 'fbid:' + ctx.userID,
+      'author_email' : '',
+      'ephemeral_ttl_mode' : '0',
+      'is_filtered_content' : false,
+      'is_filtered_content_account' : false,
+      'is_filtered_content_bh' : false,
+      'is_filtered_content_invalid_app' : false,
+      'is_filtered_content_quasar' : false,
+      'is_forward' : false,
+      'is_spoof_warning' : false,
+      'is_unread' : false,
+      'log_message_type' : 'log:thread-image',
+      'manual_retry_cnt' : '0',
+      'message_id' : messageAndOTID,
+      'offline_threading_id' : messageAndOTID,
+      'source' : 'source:chat:web',
+      'source_tags[0]' : 'source:chat',
+      'status' : '0',
+      'thread_fbid' : threadID,
+      'thread_id' : '',
+      'timestamp' : Date.now(),
+      'timestamp_absolute' : 'Today',
+      'timestamp_relative' : utils.generateTimestampRelative(),
+      'timestamp_time_passed' : '0',
     };
 
     handleUpload(image, function (err, payload) {
@@ -80,14 +80,14 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback(err);
       }
 
-      form['message_batch[0][log_message_data][image][fbid]'] = payload[0]['fbid'];
-      form['message_batch[0][log_message_data][image][filename]'] = payload[0]['filename'];
-      form['message_batch[0][log_message_data][image][filetype]'] = payload[0]['filetype'];
-      form['message_batch[0][log_message_data][image][image_id]'] = payload[0]['image_id'];
-      form['message_batch[0][log_message_data][image][src]'] = payload[0]['src'];
+      form['log_message_data[image][fbid]'] = payload[0]['fbid'];
+      form['log_message_data[image][filename]'] = payload[0]['filename'];
+      form['log_message_data[image][filetype]'] = payload[0]['filetype'];
+      form['log_message_data[image][image_id]'] = payload[0]['image_id'];
+      form['log_message_data[image][src]'] = payload[0]['src'];
 
       defaultFuncs
-        .post("https://www.facebook.com/ajax/mercury/send_messages.php", ctx.jar, form)
+        .post("https://www.facebook.com/messaging/send/", ctx.jar, form)
         .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
         .then(function(resData) {
           // check for errors here

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -87,36 +87,36 @@ module.exports = function(defaultFuncs, api, ctx) {
     // 3. No additional form params and the message goes to an existing group chat.
     if(utils.getType(threadID) === "Array") {
       for (var i  = 0; i < threadID.length; i++) {
-        form['message_batch[0][specific_to_list][' + i + ']'] = "fbid:" + threadID[i];
+        form['specific_to_list[' + i + ']'] = "fbid:" + threadID[i];
       }
-      form['message_batch[0][specific_to_list][' + (threadID.length) + ']'] = "fbid:" + ctx.userID;
-      form['message_batch[0][client_thread_id]'] = "root:" + messageAndOTID;
+      form['specific_to_list[' + (threadID.length) + ']'] = "fbid:" + ctx.userID;
+      form['client_thread_id'] = "root:" + messageAndOTID;
       log.info("Sending message to multiple users: " + threadID);
     } else {
       // This means that threadID is the id of a user, and the chat
       // is a single person chat
       if(isSingleUser) {
-        form['message_batch[0][specific_to_list][0]'] = "fbid:" + threadID;
-        form['message_batch[0][specific_to_list][1]'] = "fbid:" + ctx.userID;
-        form['message_batch[0][other_user_fbid]'] = threadID;
+        form['specific_to_list[0]'] = "fbid:" + threadID;
+        form['specific_to_list[1]'] = "fbid:" + ctx.userID;
+        form['other_user_fbid'] = threadID;
       } else {
-        form['message_batch[0][thread_fbid]'] = threadID;
+        form['thread_fbid'] = threadID;
       }
     }
 
     if(ctx.globalOptions.pageID) {
-      form['message_batch[0][author]'] = "fbid:" + ctx.globalOptions.pageID;
-      form['message_batch[0][specific_to_list][1]'] = "fbid:" + ctx.globalOptions.pageID;
-      form['message_batch[0][creator_info][creatorID]'] = ctx.userID;
-      form['message_batch[0][creator_info][creatorType]'] = "direct_admin";
-      form['message_batch[0][creator_info][labelType]'] = "sent_message";
-      form['message_batch[0][creator_info][pageID]'] = ctx.globalOptions.pageID;
+      form['author'] = "fbid:" + ctx.globalOptions.pageID;
+      form['specific_to_list[1]'] = "fbid:" + ctx.globalOptions.pageID;
+      form['creator_info[creatorID]'] = ctx.userID;
+      form['creator_info[creatorType]'] = "direct_admin";
+      form['creator_info[labelType]'] = "sent_message";
+      form['creator_info[pageID]'] = ctx.globalOptions.pageID;
       form['request_user_id'] = ctx.globalOptions.pageID;
-      form['message_batch[0][creator_info][profileURI]'] = "https://www.facebook.com/profile.php?id=" + ctx.userID;
+      form['creator_info[profileURI]'] = "https://www.facebook.com/profile.php?id=" + ctx.userID;
     }
 
     defaultFuncs
-      .post("https://www.facebook.com/ajax/mercury/send_messages.php", ctx.jar, form)
+      .post("https://www.facebook.com/messaging/send/", ctx.jar, form)
       .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
       .then(function(resData) {
         if (!resData) {
@@ -163,13 +163,13 @@ module.exports = function(defaultFuncs, api, ctx) {
 
   function handleUrl(msg, form, callback, cb) {
     if (msg.url) {
-      form['message_batch[0][shareable_attachment][share_type]'] = '100';
+      form['shareable_attachment[share_type]'] = '100';
       getUrl(msg.url, function (err, params) {
         if (err) {
           return callback(err);
         }
 
-        form['message_batch[0][shareable_attachment][share_params]'] = params;
+        form['shareable_attachment[share_params]'] = params;
         cb();
       });
     } else {
@@ -179,18 +179,18 @@ module.exports = function(defaultFuncs, api, ctx) {
 
   function handleSticker(msg, form, callback, cb) {
     if (msg.sticker) {
-      form['message_batch[0][sticker_id]'] = msg.sticker;
+      form['sticker_id'] = msg.sticker;
     }
     cb();
   }
 
   function handleAttachment(msg, form, callback, cb) {
     if (msg.attachment) {
-      form['message_batch[0][image_ids]'] = [];
-      form['message_batch[0][gif_ids]'] = [];
-      form['message_batch[0][file_ids]'] = [];
-      form['message_batch[0][video_ids]'] = [];
-      form['message_batch[0][audio_ids]'] = [];
+      form['image_ids'] = [];
+      form['gif_ids'] = [];
+      form['file_ids'] = [];
+      form['video_ids'] = [];
+      form['audio_ids'] = [];
 
       if (utils.getType(msg.attachment) !== 'Array') {
         msg.attachment = [msg.attachment];
@@ -204,7 +204,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         files.forEach(function (file) {
           var key = Object.keys(file);
           var type = key[0]; // image_id, file_id, etc
-          form['message_batch[0][' + type + 's]'].push(file[type]); // push the id
+          form['' + type + 's'].push(file[type]); // push the id
         });
         cb();
       });
@@ -246,34 +246,34 @@ module.exports = function(defaultFuncs, api, ctx) {
 
     var form = {
       'client' : 'mercury',
-      'message_batch[0][action_type]' : 'ma-type:user-generated-message',
-      'message_batch[0][author]' : 'fbid:' + ctx.userID,
-      'message_batch[0][timestamp]' : Date.now(),
-      'message_batch[0][timestamp_absolute]' : 'Today',
-      'message_batch[0][timestamp_relative]' : utils.generateTimestampRelative(),
-      'message_batch[0][timestamp_time_passed]' : '0',
-      'message_batch[0][is_unread]' : false,
-      'message_batch[0][is_cleared]' : false,
-      'message_batch[0][is_forward]' : false,
-      'message_batch[0][is_filtered_content]' : false,
-      'message_batch[0][is_filtered_content_bh]':false,
-      'message_batch[0][is_filtered_content_account]':false,
-      'message_batch[0][is_filtered_content_quasar]':false,
-      'message_batch[0][is_filtered_content_invalid_app]':false,
-      'message_batch[0][is_spoof_warning]' : false,
-      'message_batch[0][source]' : 'source:chat:web',
-      'message_batch[0][source_tags][0]' : 'source:chat',
-      'message_batch[0][body]' : msg.body ? msg.body.toString() : "",
-      'message_batch[0][html_body]' : false,
-      'message_batch[0][ui_push_phase]' : 'V3',
-      'message_batch[0][status]' : '0',
-      'message_batch[0][offline_threading_id]' : messageAndOTID,
-      'message_batch[0][message_id]' : messageAndOTID,
-      'message_batch[0][threading_id]': utils.generateThreadingID(ctx.clientID),
-      'message_batch[0][ephemeral_ttl_mode]:': '0',
-      'message_batch[0][manual_retry_cnt]' : '0',
-      'message_batch[0][has_attachment]' : !!(msg.attachment || msg.url || msg.sticker),
-      'message_batch[0][signatureID]' : utils.getSignatureID(),
+      'action_type' : 'ma-type:user-generated-message',
+      'author' : 'fbid:' + ctx.userID,
+      'timestamp' : Date.now(),
+      'timestamp_absolute' : 'Today',
+      'timestamp_relative' : utils.generateTimestampRelative(),
+      'timestamp_time_passed' : '0',
+      'is_unread' : false,
+      'is_cleared' : false,
+      'is_forward' : false,
+      'is_filtered_content' : false,
+      'is_filtered_content_bh':false,
+      'is_filtered_content_account':false,
+      'is_filtered_content_quasar':false,
+      'is_filtered_content_invalid_app':false,
+      'is_spoof_warning' : false,
+      'source' : 'source:chat:web',
+      'source_tags[0]' : 'source:chat',
+      'body' : msg.body ? msg.body.toString() : "",
+      'html_body' : false,
+      'ui_push_phase' : 'V3',
+      'status' : '0',
+      'offline_threading_id' : messageAndOTID,
+      'message_id' : messageAndOTID,
+      'threading_id': utils.generateThreadingID(ctx.clientID),
+      'ephemeral_ttl_mode:': '0',
+      'manual_retry_cnt' : '0',
+      'has_attachment' : !!(msg.attachment || msg.url || msg.sticker),
+      'signatureID' : utils.getSignatureID(),
     };
 
     handleSticker(msg, form, callback,

--- a/src/setTitle.js
+++ b/src/setTitle.js
@@ -16,34 +16,34 @@ module.exports = function(defaultFuncs, api, ctx) {
     var messageAndOTID = utils.generateOfflineThreadingID();
     var form = {
       'client' : 'mercury',
-      'message_batch[0][action_type]' : 'ma-type:log-message',
-      'message_batch[0][author]' : 'fbid:' + ctx.userID,
-      'message_batch[0][thread_id]' : '',
-      'message_batch[0][author_email]' : '',
-      'message_batch[0][coordinates]' : '',
-      'message_batch[0][timestamp]' : Date.now(),
-      'message_batch[0][timestamp_absolute]' : 'Today',
-      'message_batch[0][timestamp_relative]' : utils.generateTimestampRelative(),
-      'message_batch[0][timestamp_time_passed]' : '0',
-      'message_batch[0][is_unread]' : false,
-      'message_batch[0][is_cleared]' : false,
-      'message_batch[0][is_forward]' : false,
-      'message_batch[0][is_filtered_content]' : false,
-      'message_batch[0][is_spoof_warning]' : false,
-      'message_batch[0][source]' : 'source:chat:web',
-      'message_batch[0][source_tags][0]' : 'source:chat',
-      'message_batch[0][status]' : '0',
-      'message_batch[0][offline_threading_id]' : messageAndOTID,
-      'message_batch[0][message_id]' : messageAndOTID,
-      'message_batch[0][threading_id]': utils.generateThreadingID(ctx.clientID),
-      'message_batch[0][manual_retry_cnt]' : '0',
-      'message_batch[0][thread_fbid]' : threadID,
-      'message_batch[0][log_message_data][name]' : newTitle,
-      'message_batch[0][log_message_type]' : 'log:thread-name'
+      'action_type' : 'ma-type:log-message',
+      'author' : 'fbid:' + ctx.userID,
+      'thread_id' : '',
+      'author_email' : '',
+      'coordinates' : '',
+      'timestamp' : Date.now(),
+      'timestamp_absolute' : 'Today',
+      'timestamp_relative' : utils.generateTimestampRelative(),
+      'timestamp_time_passed' : '0',
+      'is_unread' : false,
+      'is_cleared' : false,
+      'is_forward' : false,
+      'is_filtered_content' : false,
+      'is_spoof_warning' : false,
+      'source' : 'source:chat:web',
+      'source_tags[0]' : 'source:chat',
+      'status' : '0',
+      'offline_threading_id' : messageAndOTID,
+      'message_id' : messageAndOTID,
+      'threading_id': utils.generateThreadingID(ctx.clientID),
+      'manual_retry_cnt' : '0',
+      'thread_fbid' : threadID,
+      'log_message_data[name]' : newTitle,
+      'log_message_type' : 'log:thread-name'
     };
 
     defaultFuncs
-      .post("https://www.facebook.com/ajax/mercury/send_messages.php", ctx.jar, form)
+      .post("https://www.facebook.com/messaging/send/", ctx.jar, form)
       .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
       .then(function(resData) {
         if (resData.error && resData.error === 1545012){


### PR DESCRIPTION
Related to bug #311. Pull request #315 only attempted to fix sendMessage, this includes 3 more services.

Functions updated:

- addUserToGroup
- changeGroupImage
- sendMessage
- setTitle

Changes made:

- Remove `message_batch[0]`
- Change https://www.facebook.com/ajax/mercury/send_messages.php to https://www.facebook.com/messaging/send/

The unit testing currently produces 30 passes and 5 failures for me.

- Login As Page:
  1. should send text message object (user)
  2. should send sticker message object (user)
  3. should send basic string (user)
  4. should get a list of online users
- Login:
  5) should get a list of online users

The errors indicate:
- The URL for getOnlineUsers, https://www.facebook.com/ajax/chat/buddy_list.php, also returns a 404. I haven't been able to find the new URL and/or formatting for this.
- Things in Login As Page that send messages are not sent with an error saying "This person isn't receiving messages from you right now." (this may just be an issue with my test users/pages)