### PR TITLE
markAsRead has additional parameters

### DIFF
--- a/src/markAsRead.js
+++ b/src/markAsRead.js
@@ -11,6 +11,10 @@ module.exports = function(defaultFuncs, api, ctx) {
 
     var form = {};
     form["ids[" + threadID + "]"] = true;
+    form["watermarkTimestamp"] = new Date().getTime();
+    form["shouldSendReadReceipt"] = true;
+    form["commerce_last_message_type"] = "non_ad";
+    form["titanOriginatedThreadId"] = utils.generateThreadingID(ctx.clientID);
 
     defaultFuncs
       .post("https://www.facebook.com/ajax/mercury/change_read_status.php", ctx.jar, form)


### PR DESCRIPTION
Pull request from issue #329. All unit tests pass.

Note that I have not noticed that these changes are necessary for markAsRead to function as intended. The issue with #329 only happens on one thread that I know of, and appears to be an issue with Facebook, not this API. While investigating, I found that the official site included more parameters than this API did. These parameters may become important at some time in the future.