### PR TITLE
allow node versions > 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "request": "^2.53.0"
   },
   "engines": {
-    "node": "4.x"
+    "node": ">=4.x"
   },
   "devDependencies": {
     "mocha": "^2.2.5"


### PR DESCRIPTION
this fixes compatibility with yarn which doesn't allow you to install packages that don't allow your current node version

cheers! :smile: