### PR TITLE
getThreadHistory: Filter out messages containing error attachments

### DIFF
--- a/src/getThreadHistory.js
+++ b/src/getThreadHistory.js
@@ -51,7 +51,7 @@ module.exports = function(defaultFuncs, api, ctx) {
               delete v.author;
             });
 
-            callback(null, resData.payload.actions.map(utils.formatMessage));
+            callback(null, resData.payload.actions.map(utils.formatMessage).filter(utils.filterOutErrors));
           });
         })
         .catch(function(err) {

--- a/src/getThreadHistory.js
+++ b/src/getThreadHistory.js
@@ -51,7 +51,7 @@ module.exports = function(defaultFuncs, api, ctx) {
               delete v.author;
             });
 
-            callback(null, resData.payload.actions.map(utils.formatMessage).filter(utils.filterOutErrors));
+            callback(null, resData.payload.actions.map(utils.formatMessage));
           });
         })
         .catch(function(err) {

--- a/utils.js
+++ b/utils.js
@@ -228,6 +228,16 @@ function getGUID() {
   return id;
 }
 
+function filterOutErrors(message) {
+  var hasErrors = message.attachments.some(att => att.type === "error");
+
+  if (hasErrors) {
+    log.warn("Message contains error attachments", message);
+  }
+
+  return !hasErrors;
+}
+
 function _formatAttachment(attachment1, attachment2) {
   // TODO: THIS IS REALLY BAD
   // This is an attempt at fixing Facebook's inconsistencies. Sometimes they give us
@@ -333,6 +343,15 @@ function _formatAttachment(attachment1, attachment2) {
         width: attachment1.metadata.dimensions.width,
         height: attachment1.metadata.dimensions.height,
         duration: attachment1.metadata.duration,
+      };
+    case "error":
+      return {
+        type: "error",
+
+        // Save error attachments because we're unsure of their format,
+        // and whether there are cases they contain something useful for debugging.
+        attachment1: attachment1,
+        attachment2: attachment2
       };
     default:
       throw new Error("unrecognized attach_file `" + JSON.stringify(attachment1) + "`");
@@ -677,6 +696,7 @@ module.exports = {
   parseAndCheckLogin: parseAndCheckLogin,
   saveCookies: saveCookies,
   getType: getType,
+  filterOutErrors: filterOutErrors,
   formatMessage: formatMessage,
   formatDeltaMessage: formatDeltaMessage,
   formatEvent: formatEvent,

--- a/utils.js
+++ b/utils.js
@@ -228,16 +228,6 @@ function getGUID() {
   return id;
 }
 
-function filterOutErrors(message) {
-  var hasErrors = message.attachments.some(att => att.type === "error");
-
-  if (hasErrors) {
-    log.warn("Message contains error attachments", message);
-  }
-
-  return !hasErrors;
-}
-
 function _formatAttachment(attachment1, attachment2) {
   // TODO: THIS IS REALLY BAD
   // This is an attempt at fixing Facebook's inconsistencies. Sometimes they give us
@@ -696,7 +686,6 @@ module.exports = {
   parseAndCheckLogin: parseAndCheckLogin,
   saveCookies: saveCookies,
   getType: getType,
-  filterOutErrors: filterOutErrors,
   formatMessage: formatMessage,
   formatDeltaMessage: formatDeltaMessage,
   formatEvent: formatEvent,


### PR DESCRIPTION
Fixes #357 