### PR TITLE
Expose resolvePhotoUrl() for resolving URLs on demand

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -26,6 +26,7 @@
 * [`api.markAsRead`](#markAsRead)
 * [`api.muteThread`](#muteThread)
 * [`api.removeUserFromGroup`](#removeUserFromGroup)
+* [`api.resolvePhotoUrl`](#resolvePhotoUrl)
 * [`api.searchForThread`](#searchForThread)
 * [`api.sendMessage`](#sendMessage)
 * [`api.sendTypingIndicator`](#sendTypingIndicator)
@@ -700,6 +701,19 @@ __Arguments__
 * `userID`: User ID.
 * `threadID`: Group chat ID.
 * `callback(err)`: A callback called when the query is done (either with an error or with no arguments).
+
+---------------------------------------
+
+<a name="resolvePhotoUrl" />
+### api.resolvePhotoUrl(photoID, callback)
+
+Resolves the URL to the full-size photo, given its ID. This function is useful for retrieving the full-size photo URL
+of image attachments in messages, returned by [`api.getThreadHistory`](#getThreadHistory).
+
+__Arguments__
+
+* `photoID`: Photo ID.
+* `callback(err, url)`: A callback called when the query is done (either with an error or with the photo's URL). `url` is a string with the photo's URL. 
 
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Result:
 * [`api.markAsRead`](DOCS.md#markAsRead)
 * [`api.muteThread`](DOCS.md#muteThread)
 * [`api.removeUserFromGroup`](DOCS.md#removeUserFromGroup)
+* [`api.resolvePhotoUrl`](DOCS.md#resolvePhotoUrl)
 * [`api.searchForThread`](DOCS.md#searchForThread)
 * [`api.sendMessage`](DOCS.md#sendMessage)
 * [`api.sendTypingIndicator`](DOCS.md#sendTypingIndicator)

--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ function buildAPI(globalOptions, html, jar) {
     'markAsRead',
     'muteThread',
     'removeUserFromGroup',
+    'resolvePhotoUrl',
     'searchForThread',
     'sendMessage',
     'sendTypingIndicator',

--- a/src/listen.js
+++ b/src/listen.js
@@ -2,7 +2,6 @@
 
 var utils = require("../utils");
 var log = require("npmlog");
-var resolvePhotoUrlModule = require("./resolvePhotoUrl");
 
 var msgsRecv = 0;
 var identity = function() {};
@@ -18,8 +17,6 @@ module.exports = function(defaultFuncs, api, ctx) {
       currentlyRunning = null;
     }
   };
-
-  var resolvePhotoUrl = resolvePhotoUrlModule(defaultFuncs, api, ctx);
 
   var prev = Date.now();
   var tmpPrev = Date.now();
@@ -145,7 +142,7 @@ module.exports = function(defaultFuncs, api, ctx) {
                     return (!ctx.globalOptions.selfListen && fmtMsg.senderID === ctx.userID) ? undefined : globalCallback(null, fmtMsg);
                   } else {
                     if (v.delta.attachments[i].mercury.attach_type == 'photo') {
-                      resolvePhotoUrl(v.delta.attachments[i].fbid, (err, url) => {
+                      api.resolvePhotoUrl(v.delta.attachments[i].fbid, (err, url) => {
                         if (!err) v.delta.attachments[i].mercury.metadata.url = url;
                         return resolveAttachmentUrl(i + 1);
                       });

--- a/src/listen.js
+++ b/src/listen.js
@@ -2,6 +2,7 @@
 
 var utils = require("../utils");
 var log = require("npmlog");
+var resolvePhotoUrlModule = require("./resolvePhotoUrl");
 
 var msgsRecv = 0;
 var identity = function() {};
@@ -17,6 +18,8 @@ module.exports = function(defaultFuncs, api, ctx) {
       currentlyRunning = null;
     }
   };
+
+  var resolvePhotoUrl = resolvePhotoUrlModule(defaultFuncs, api, ctx);
 
   var prev = Date.now();
   var tmpPrev = Date.now();
@@ -142,8 +145,8 @@ module.exports = function(defaultFuncs, api, ctx) {
                     return (!ctx.globalOptions.selfListen && fmtMsg.senderID === ctx.userID) ? undefined : globalCallback(null, fmtMsg);
                   } else {
                     if (v.delta.attachments[i].mercury.attach_type == 'photo') {
-                      utils.resolvePhotoUrl(v.delta.attachments[i].fbid, defaultFuncs, ctx, (err, url) => {
-                        if (!err) v.delta.attachments[i].mercury.url = url;
+                      resolvePhotoUrl(v.delta.attachments[i].fbid, (err, url) => {
+                        if (!err) v.delta.attachments[i].mercury.metadata.url = url;
                         return resolveAttachmentUrl(i + 1);
                       });
                     }

--- a/src/listen.js
+++ b/src/listen.js
@@ -142,13 +142,10 @@ module.exports = function(defaultFuncs, api, ctx) {
                     return (!ctx.globalOptions.selfListen && fmtMsg.senderID === ctx.userID) ? undefined : globalCallback(null, fmtMsg);
                   } else {
                     if (v.delta.attachments[i].mercury.attach_type == 'photo') {
-                      defaultFuncs
-                        .get("https://www.facebook.com/mercury/attachments/photo/?photo_id=" + v.delta.attachments[i].fbid, ctx.jar, {})
-                        .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
-                        .then(function (resData) {
-                          if (!resData.error) v.delta.attachments[i].mercury.url = resData.jsmods.require[0][3][0]
-                          return resolveAttachmentUrl(i + 1);
-                        })
+                      utils.resolvePhotoUrl(v.delta.attachments[i].fbid, defaultFuncs, ctx, (err, url) => {
+                        if (!err) v.delta.attachments[i].mercury.url = url;
+                        return resolveAttachmentUrl(i + 1);
+                      });
                     }
                   }
                 })(0)

--- a/src/resolvePhotoUrl.js
+++ b/src/resolvePhotoUrl.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var utils = require("../utils");
+
+module.exports = function (defaultFuncs, api, ctx) {
+  return function resolvePhotoUrl(photoID, callback) {
+    if (!callback) {
+      throw { error: "resolvePhotoUrl: need callback" };
+    }
+
+    utils.resolvePhotoUrl(photoID, defaultFuncs, ctx, callback);
+  };
+};

--- a/utils.js
+++ b/utils.js
@@ -691,25 +691,6 @@ function formatThread(data) {
   };
 }
 
-function resolvePhotoUrl(photoID, defaultFuncs, ctx, callback) {
-  defaultFuncs
-    .get("https://www.facebook.com/mercury/attachments/photo", ctx.jar, { photo_id: photoID })
-    .then(parseAndCheckLogin(ctx.jar, defaultFuncs))
-    .then(resData => {
-      if (resData.error) {
-        throw resData;
-      }
-
-      var photoUrl = resData.jsmods.require[0][3][0];
-
-      return callback(null, photoUrl);
-    })
-    .catch(err => {
-      log.error("Error in resolvePhotoUrl", err);
-      return callback(err);
-    });
-}
-
 
 function getType(obj) {
   return Object.prototype.toString.call(obj).slice(8, -1);
@@ -748,7 +729,6 @@ module.exports = {
   makeDefaults: makeDefaults,
   parseAndCheckLogin: parseAndCheckLogin,
   saveCookies: saveCookies,
-  resolvePhotoUrl: resolvePhotoUrl,
   getType: getType,
   formatMessage: formatMessage,
   formatDeltaMessage: formatDeltaMessage,

--- a/utils.js
+++ b/utils.js
@@ -691,6 +691,25 @@ function formatThread(data) {
   };
 }
 
+function resolvePhotoUrl(photoID, defaultFuncs, ctx, callback) {
+  defaultFuncs
+    .get("https://www.facebook.com/mercury/attachments/photo", ctx.jar, { photo_id: photoID })
+    .then(parseAndCheckLogin(ctx.jar, defaultFuncs))
+    .then(resData => {
+      if (resData.error) {
+        throw resData;
+      }
+
+      var photoUrl = resData.jsmods.require[0][3][0];
+
+      return callback(null, photoUrl);
+    })
+    .catch(err => {
+      log.error("Error in resolvePhotoUrl", err);
+      return callback(err);
+    });
+}
+
 
 function getType(obj) {
   return Object.prototype.toString.call(obj).slice(8, -1);
@@ -729,6 +748,7 @@ module.exports = {
   makeDefaults: makeDefaults,
   parseAndCheckLogin: parseAndCheckLogin,
   saveCookies: saveCookies,
+  resolvePhotoUrl: resolvePhotoUrl,
   getType: getType,
   formatMessage: formatMessage,
   formatDeltaMessage: formatDeltaMessage,


### PR DESCRIPTION
We can get photo attachments not only through `listen()` where the photo URL resolving was originally implemented, but also through `getThreadHistory()` where the `url` property of photos gets returned as `undefined`. I thought about resolving the URLs there but it didn't seem like a good idea, and would've probably made `getThreadHistory()` significantly slower.

So I think it's a good idea to expose this function to developers, so they can resolve photo URLs whenever they deem necessary.

I've implemented it in `utils.js` so we can reuse the code in `api.listen()` and `api.resolvePhotoUrl()`.