### PR TITLE
Make it possible to fetch threads from the 'other' folder

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -401,7 +401,7 @@ __Arguments__
 
 * `start`: Start index in the list of recently used threads.
 * `end`: End index.
-* `type`: Optional String, can be 'inbox', 'pending', or 'archived'. Inbox is default.
+* `type`: Optional String, can be 'inbox', 'pending', 'archived' or 'other'. Inbox is default.
 * `callback(err, arr)`: A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of thread object containing the following properties: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `nicknames`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID`.
 
 ---------------------------------------

--- a/src/getThreadList.js
+++ b/src/getThreadList.js
@@ -26,9 +26,9 @@ module.exports = function(defaultFuncs, api, ctx) {
 
     if (type === 'archived') {
       type = 'action:archived';
-    } else if (type !== 'inbox' && type !== 'pending') {
+    } else if (type !== 'inbox' && type !== 'pending' && type !== 'other') {
       throw {
-        error: "type can only be one of the following: inbox, pending, archived"
+        error: "type can only be one of the following: inbox, pending, archived, other"
       }
     }
 


### PR DESCRIPTION
This allows users to deal with threads in the "hidden" inbox folder where Facebook sometimes auto routes incoming messages.