### PR TITLE
Multiple updates and fixes to DOCS and README

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -34,6 +34,35 @@
 
 ---------------------------------------
 
+### Password safety
+
+**Read this** before you _copy+paste_ examples from below.
+
+You should not store Facebook password in your scripts.
+There are few good reasons:
+* People who are standing behind you may look at your "code" and get your password if it is on the screen
+* Backups of source files may be readable by someone else. "_There is nothing secret in my code, why should I ever password protect my backups_"
+* You can't push your code to Github (or any onther service) without removing your password from the file.  Remember: Even if you undo your accidential commit with password, Git doesn't delete it, that commit is just not used but is still readable by everybody.
+* If you change your password in the future (maybe it leaked because _someone_ stored password in source file… oh… well…) you will have to change every occurrence in your scripts
+
+Preferred method is to have `login.js` that saves `AppState` to a file and then use that file from all your scripts.
+This way you can put password in your code for a minute, login to facebook and then remove it.
+
+If you want to be even more safe:  _login.js_ can get password with `require("readline")` or with environment variables like this:
+```js
+var credentials = {
+    email: process.env.FB_EMAIL,
+    password: process.env.FB_PASSWORD
+}
+```
+```bash
+FB_EMAIL="john.doe@example.com"
+FB_PASSWORD="MySuperHardP@ssw0rd"
+nodejs login.js
+```
+
+---------------------------------------
+
 <a name="login"/>
 ### login(credentials[, options], callback)
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -5,11 +5,12 @@
 * [`api.changeArchivedStatus`](#changeArchivedStatus)
 * [`api.changeBlockedStatus`](#changeBlockedStatus)
 * [`api.changeGroupImage`](#changeGroupImage)
+* [`api.changeNickname`](#changeNickname)
 * [`api.changeThreadColor`](#changeThreadColor)
 * [`api.changeThreadEmoji`](#changeThreadEmoji)
-* [`api.changeNickname`](#changeNickname)
 * [`api.createPoll`](#createPoll)
 * [`api.deleteMessage`](#deleteMessage)
+* [`api.deleteThread`](#deleteThread)
 * [`api.getAppState`](#getAppState)
 * [`api.getCurrentUserID`](#getCurrentUserID)
 * [`api.getFriendsList`](#getFriendsList)
@@ -17,7 +18,6 @@
 * [`api.getThreadInfo`](#getThreadInfo)
 * [`api.getThreadList`](#getThreadList)
 * [`api.getThreadPictures`](#getThreadPictures)
-* [`api.deleteThread`](#deleteThread)
 * [`api.getUserID`](#getUserID)
 * [`api.getUserInfo`](#getUserInfo)
 * [`api.handleMessageRequest`](#handleMessageRequest)
@@ -35,7 +35,7 @@
 ---------------------------------------
 
 <a name="login"/>
-### login(credentials, [options], callback)
+### login(credentials[, options], callback)
 
 This function is returned by `require(...)` and is the main entry point to the API.
 
@@ -54,7 +54,9 @@ __Arguments__
 __Example (Email & Password)__
 
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const login = require("facebook-chat-api");
+
+login({email: "FB_EMAIL", password: "FB_PASSWORD"}, (err, api) => {
     if(err) return console.error(err);
     // Here you can use the api
 });
@@ -63,7 +65,10 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 __Example (Email & Password then save appState to file)__
 
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({email: "FB_EMAIL", password: "FB_PASSWORD"}, (err, api) => {
     if(err) return console.error(err);
 
     fs.writeFileSync('appstate.json', JSON.stringify(api.getAppState()));
@@ -73,7 +78,10 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 __Example (AppState loaded from file)__
 
 ```js
-login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, function callback (err, api) {
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
     // Here you can use the api
 });
@@ -84,27 +92,32 @@ __Login Approvals (2-Factor Auth)__: When you try to login with Login Approvals 
 __Example__:
 
 ```js
-var readline = require("readline");
+const fs = require("fs");
+const login = require("facebook-chat-api");
+const readline = require("readline");
+
 var rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout
 });
 
-login(obj, function(err, api) {
-  if(err) {
-    switch (err.error) {
-      case 'login-approval':
-        console.log('Enter code > ');
-        rl.on('line', function(line){
-          err.continue(line);
-          rl.close();
-        });
-        break;
+login(obj, (err, api) => {
+    if(err) {
+        switch (err.error) {
+            case 'login-approval':
+                console.log('Enter code > ');
+                rl.on('line', (line) => {
+                    err.continue(line);
+                    rl.close();
+                });
+                break;
+            default:
+                console.error(err);
+        }
+        return;
     }
-    return;
-  }
 
-  // Logged in!
+    // Logged in!
 }
 ```
 
@@ -114,7 +127,7 @@ __Review Recent Login__: Sometimes Facebook will ask you to review your recent l
 ---------------------------------------
 
 <a name="addUserToGroup" />
-### api.addUserToGroup(userID, threadID, [callback])
+### api.addUserToGroup(userID, threadID[, callback])
 
 Adds a user (or array of users) to a group chat.
 
@@ -127,7 +140,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="changeArchivedStatus" />
-### api.changeArchivedStatus(threadOrThreads, archive, [callback])
+### api.changeArchivedStatus(threadOrThreads, archive[, callback])
 
 Given a threadID, or an array of threadIDs, will set the archive status of the threads to `archive`. Archiving a thread will hide it from the logged-in user's inbox until the next time a message is sent or received.
 
@@ -139,12 +152,13 @@ __Arguments__
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.changeArchivedStatus("0000000000000", true, function callback(err) {
+    api.changeArchivedStatus("000000000000000", true, (err) => {
         if(err) return console.error(err);
     });
 });
@@ -153,7 +167,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="changeBlockedStatus" />
-### api.changeBlockedStatus(userID, block, [callback])
+### api.changeBlockedStatus(userID, block[, callback])
 
 Prevents a user from privately contacting you. (Messages in a group chat will still be seen by both parties).
 
@@ -166,7 +180,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="changeGroupImage" />
-### api.changeGroupImage(image, threadID, [callback])
+### api.changeGroupImage(image, threadID[, callback])
 
 Will change the group chat's image to the given image.
 
@@ -178,12 +192,41 @@ __Arguments__
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.changeGroupImage(fs.createReadStream("./avatar.png"), "0000000000000", function callback(err) {
+    api.changeGroupImage(fs.createReadStream("./avatar.png"), "000000000000000", (err) => {
+        if(err) return console.error(err);
+    });
+});
+```
+
+---------------------------------------
+
+<a name="changeNickname" />
+### api.changeNickname(nickname, threadID, participantID[, callback])
+
+Will change the thread user nickname to the one provided.
+
+__Arguments__
+* `nickname`: String containing a nickname. Leave empty to reset nickname.
+* `threadID`: String representing the ID of the thread.
+* `participantID`: String representing the ID of the user.
+* `callback(err)`: An optional callback called when the change is done (either with an error or null).
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if(err) return console.error(err);
+
+    api.changeNickname("Example", "000000000000000", "000000000000000", (err) => {
         if(err) return console.error(err);
     });
 });
@@ -192,7 +235,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="changeThreadColor" />
-### api.changeThreadColor(color, threadID, [callback])
+### api.changeThreadColor(color, threadID[, callback])
 
 Will change the thread color to the given hex string color ("#0000ff"). Set it
 to empty string if you want the default.
@@ -207,12 +250,13 @@ __Arguments__
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.changeThreadColor("#0000ff", "0000000000000", function callback(err) {
+    api.changeThreadColor("#0000ff", "000000000000000", (err) => {
         if(err) return console.error(err);
     });
 });
@@ -221,7 +265,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="changeThreadEmoji" />
-### api.changeThreadEmoji(emoji, threadID, [callback])
+### api.changeThreadEmoji(emoji, threadID[, callback])
 
 Will change the thread emoji to the one provided.
 
@@ -235,39 +279,13 @@ __Arguments__
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.changeThreadEmoji("💯", "0000000000000", function callback(err) {
-        if(err) return console.error(err);
-    });
-});
-```
-
----------------------------------------
-
-<a name="changeNickname" />
-### api.changeNickname(nickname, threadID, participantID, [callback])
-
-Will change the thread user nickname to the one provided.
-
-__Arguments__
-* `nickname`: String containing a nickname. Leave empty to reset nickname.
-* `threadID`: String representing the ID of the thread.
-* `participantID`: String representing the ID of the user.
-* `callback(err)`: An optional callback called when the change is done (either with an error or null).
-
-__Example__
-
-```js
-var login = require("facebook-chat-api");
-
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
-    if(err) return console.error(err);
-
-    api.changeNickname("Example", "0000000000000", "0000000000000", function callback(err) {
+    api.changeThreadEmoji("💯", "000000000000000", (err) => {
         if(err) return console.error(err);
     });
 });
@@ -276,7 +294,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="createPoll" />
-### api.createPoll(title, threadID, [options, callback])
+### api.createPoll(title, threadID[, options][, callback])
 
 Creates a poll with the specified title and optional poll options, which can also be initially selected by the logged-in user.
 
@@ -284,20 +302,21 @@ __Arguments__
 * `title`: String containing a title for the poll.
 * `threadID`: String representing the ID of the thread.
 * `options`: An optional `string : bool` dictionary to specify initial poll options and their initial states (selected/not selected), respectively.
-* `callback(err)`: An optional callback called when the poll is posted (either with an error or null) – can omit the `options` parameter and use this as the third parameter if desired.
+* `callback(err)`: An optional callback called when the poll is posted (either with an error or null) - can omit the `options` parameter and use this as the third parameter if desired.
 
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.createPoll("Example Poll", "0000000000000", {
-      "Option 1": false,
-      "Option 2": true
-    }, function callback(err) {
+    api.createPoll("Example Poll", "000000000000000", {
+        "Option 1": false,
+        "Option 2": true
+    }, (err) => {
         if(err) return console.error(err);
     });
 });
@@ -306,7 +325,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="deleteMessage" />
-### api.deleteMessage(messageOrMessages, [callback])
+### api.deleteMessage(messageOrMessages[, callback])
 
 Takes a messageID or an array of messageIDs and deletes the corresponding message.
 
@@ -316,12 +335,48 @@ __Arguments__
 
 __Example__
 ```js
-api.listen(function callback(err, message) {
-  if(message.body) {
-    api.sendMessage(message.body, message.threadID, function(error, messageInfo) {
-      api.deleteMessage(messageInfo.messageID);
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if(err) return console.error(err);
+
+    api.listen((err, message) => {
+        if(message.body) {
+            api.sendMessage(message.body, message.threadID, (err, messageInfo) => {
+                if(err) return console.error(err);
+
+                api.deleteMessage(messageInfo.messageID);
+            });
+        }
     });
-  }
+});
+```
+
+---------------------------------------
+
+<a name="deleteThread" />
+### api.deleteThread(threadOrThreads[, callback])
+
+Given a threadID, or an array of threadIDs, will delete the threads from your account. Note that this does *not* remove the messages from Facebook's servers - anyone who hasn't deleted the thread can still view all of the messages.
+
+__Arguments__
+
+* `threadOrThreads` - The id(s) of the threads you wish to remove from your account.
+* `callback(err)` - A callback called when the operation is done, maybe with an object representing an error.
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if(err) return console.error(err);
+
+    api.deleteThread("000000000000000", (err) => {
+        if(err) return console.error(err);
+    });
 });
 ```
 
@@ -353,21 +408,24 @@ __Arguments__
 __Example__
 
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
-  if(err) return console.error(err);
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-  api.getFriendsList(function(err, data) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    console.log(data.length);
-  });
+    api.getFriendsList((err, data) => {
+        if(err) return console.error(err);
+
+        console.log(data.length);
+    });
 });
 ```
 
 ---------------------------------------
 
 <a name="getThreadHistory" />
-### api.getThreadHistory(threadID, start, end, timestamp, [callback])
+### api.getThreadHistory(threadID, start, end, timestamp[, callback])
 
 Takes a threadID, start and end numbers, a timestamp, and a callback.
 
@@ -383,13 +441,13 @@ __Arguments__
 ---------------------------------------
 
 <a name="getThreadInfo" />
-### api.getThreadInfo(threadID, [callback])
+### api.getThreadInfo(threadID[, callback])
 
 Takes a threadID and a callback.  Works for both single-user and group threads.
 
 __Arguments__
 * `threadID`: A threadID corresponding to the target thread.
-* `callback(error, info)`: If error is null, info will contain participantIDs, name, snippet, messageCount, emoji, nicknames, and color.  The last three will be null if custom values are not set for the thread.
+* `callback(err, info)`: If `err` is `null`, `info` will contain `participantIDs`, `name`, `snippet`, `messageCount`, `emoji`, `nicknames`, and `color`.  The last three will be null if custom values are not set for the thread.
 
 ---------------------------------------
 
@@ -402,7 +460,7 @@ __Arguments__
 
 * `start`: Start index in the list of recently used threads.
 * `end`: End index.
-* `type`: Optional String, can be 'inbox', 'pending', 'archived' or 'other'. Inbox is default.
+* `type`: Optional String, can be 'inbox', 'pending', or 'archived'. Inbox is default.
 * `callback(err, arr)`: A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of thread object containing the following properties: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `nicknames`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID`.
 
 ---------------------------------------
@@ -421,32 +479,6 @@ __Arguments__
 
 ---------------------------------------
 
-<a name="deleteThread" />
-### api.deleteThread(threadOrThreads, [callback])
-
-Given a threadID, or an array of threadIDs, will delete the threads from your account. Note that this does *not* remove the messages from Facebook's servers - anyone who hasn't deleted the thread can still view all of the messages.
-
-__Arguments__
-
-* `threadOrThreads` - The id(s) of the threads you wish to remove from your account.
-* `callback(err)` - A callback called when the operation is done, maybe with an object representing an error.
-
-__Example__
-
-```js
-var login = require("facebook-chat-api");
-
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
-    if(err) return console.error(err);
-
-    api.deleteThread("0000000000000", function callback(err) {
-        if(err) return console.error(err);
-    });
-});
-```
-
----------------------------------------
-
 <a name="getUserID" />
 ### api.getUserID(name, callback)
 
@@ -460,13 +492,17 @@ __Arguments__
 __Example__
 
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.getUserID("Marc Zuckerbot", function(err, data) {
-        if(err) return callback(err);
+    api.getUserID("Marc Zuckerbot", (err, data) => {
+        if(err) return console.error(err);
 
         // Send the message to the best match (best by Facebook's criteria)
+        var msg = "Hello!"
         var threadID = data[0].userID;
         api.sendMessage(msg, threadID);
     });
@@ -483,22 +519,25 @@ Will get some information about the given users.
 __Arguments__
 
 * `ids` - Either a string/number for one ID or an array of strings/numbers for a batched query.
-* `callback(err, obj)` - A callback called when the query is done (either with an error or with an confirmation object). `obj` is a mapping from userId to another object containing the following properties: name, firstName, vanity, thumbSrc, profileUrl, gender, type, isFriend, isBirthday, searchTokens, alternateName.
+* `callback(err, obj)` - A callback called when the query is done (either with an error or with an confirmation object). `obj` is a mapping from userId to another object containing the following properties: `name`, `firstName`, `vanity`, `thumbSrc`, `profileUrl`, `gender`, `type`, `isFriend`, `isBirthday`, `searchTokens`, `alternateName`.
 
 __Example__
 
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.getUserInfo([1, 2, 3, 4], function(err, ret) {
-      if(err) return console.error(err);
+    api.getUserInfo([1, 2, 3, 4], (err, ret) => {
+        if(err) return console.error(err);
 
-      for(var prop in ret) {
-        if(ret.hasOwnProperty(prop) && ret[prop].isBirthday) {
-          api.sendMessage("Happy birthday :)", prop);
+        for(var prop in ret) {
+            if(ret.hasOwnProperty(prop) && ret[prop].isBirthday) {
+                api.sendMessage("Happy birthday :)", prop);
+            }
         }
-      }
     });
 });
 ```
@@ -506,7 +545,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="handleMessageRequest" />
-### api.handleMessageRequest(threadID, accept, [callback])
+### api.handleMessageRequest(threadID, accept[, callback])
 
 Accept or ignore message request(s) with thread id `threadID`.
 
@@ -592,31 +631,34 @@ If enabled through [setOptions](#setOptions), this will also return presence, (`
 __Example__
 
 ```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
 // Simple echo bot. He'll repeat anything that you say.
 // Will stop when you say '/stop'
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
     api.setOptions({listenEvents: true});
 
-    var stopListening = api.listen(function(err, event) {
+    var stopListening = api.listen((err, event) => {
         if(err) return console.error(err);
 
         switch(event.type) {
-          case "message":
-            if(event.body === '/stop') {
-              api.sendMessage("Goodbye...", event.threadID);
-              return stopListening();
-            }
-            api.markAsRead(event.threadID, function(err) {
-              if(err) console.log(err);
-            });
-            api.sendMessage("TEST BOT: " + event.body, event.threadID);
-            break;
-          case "event":
-            console.log(event);
-            break;
+            case "message":
+                if(event.body === '/stop') {
+                    api.sendMessage("Goodbye...", event.threadID);
+                    return stopListening();
+                }
+                api.markAsRead(event.threadID, (err) => {
+                    if(err) console.log(err);
+                });
+                api.sendMessage("TEST BOT: " + event.body, event.threadID);
+                break;
+            case "event":
+                console.log(event);
+                break;
         }
     });
 });
@@ -636,7 +678,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="markAsRead" />
-### api.markAsRead(threadID, [callback])
+### api.markAsRead(threadID[, callback])
 
 Given a threadID will mark all the unread messages as read. Facebook will take a couple of seconds to show that you've read the messages.
 
@@ -648,13 +690,16 @@ __Arguments__
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.listen(function callback(err, message) {
-        // Marks message as read immediately after they're sent
+    api.listen((err, message) => {
+        if(err) return console.error(err);
+
+        // Marks messages as read immediately after they're received
         api.markAsRead(message.threadID);
     });
 });
@@ -663,7 +708,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="muteThread" />
-### api.muteThread(threadID, muteSeconds, [callback])
+### api.muteThread(threadID, muteSeconds[, callback])
 
 Mute a chat for a period of time, or unmute a chat.
 
@@ -676,12 +721,15 @@ __Arguments__
 __Example__
 
 ```js
-var login = require("facebook-chat-api");
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    api.listen(function callback(err, message) {
+    api.listen((err, message) => {
+        if(err) return console.error(err);
+
         // Mute all incoming chats for one minute
         api.muteThread(message.threadID, 60);
     });
@@ -691,7 +739,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="removeUserFromGroup" />
-### api.removeUserFromGroup(userID, threadID, [callback])
+### api.removeUserFromGroup(userID, threadID[, callback])
 
 Removes a user from a group chat.
 
@@ -706,6 +754,9 @@ __Arguments__
 <a name="searchForThread" />
 ### api.searchForThread(name, callback)
 
+> This part is outdated.
+> see #396
+
 Takes a chat title (thread name) and returns matching results as a formatted threads array (ordered according to Facebook).
 
 __Arguments__
@@ -715,7 +766,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="sendMessage" />
-### api.sendMessage(message, threadID, [callback])
+### api.sendMessage(message, threadID[, callback])
 
 Sends the given message to the threadID.
 
@@ -739,10 +790,13 @@ __Tip__: to find your own ID, you can look inside the cookies. The `userID` is u
 
 __Example (Basic Message)__
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    var yourID = "0000000000000";
+    var yourID = "000000000000000";
     var msg = {body: "Hey!"};
     api.sendMessage(msg, yourID);
 });
@@ -750,14 +804,17 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 
 __Example (File upload)__
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
-    // Note this example uploads an image called image.jpg
-    var yourID = "0000000000000";
+    // This example uploads an image called image.jpg
+    var yourID = "000000000000000";
     var msg = {
-      body: "Hey!",
-      attachment: fs.createReadStream(__dirname + '/image.jpg')
+        body: "Hey!",
+        attachment: fs.createReadStream(__dirname + '/image.jpg')
     }
     api.sendMessage(msg, yourID);
 });
@@ -766,7 +823,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="sendTypingIndicator" />
-### api.sendTypingIndicator(threadID, [callback])
+### api.sendTypingIndicator(threadID[, callback])
 
 Sends a "USERNAME is typing" indicator to other members of the thread indicated by threadID.  This indication will disappear after 30 second or when the `end` function is called. The `end` function is returned by `api.sendTypingIndicator`.
 
@@ -800,20 +857,26 @@ __Arguments__
 __Example__
 
 ```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
 // Simple echo bot. This will send messages forever.
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
     api.setOptions({
-      selfListen: true,
-      logLevel: "silent"
+        selfListen: true,
+        logLevel: "silent"
     });
 
-    api.listen(function(err, message, stopListening){
+    api.listen((err, message) => {
         if(err) return console.error(err);
 
-        api.sendMessage(message.body, message.threadID);
+        // Ignore empty messages (photos etc.)
+        if (typeof message.body === "string") {
+            api.sendMessage(message.body, message.threadID);
+        }
     });
 });
 ```
@@ -821,7 +884,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ---------------------------------------
 
 <a name="setTitle" />
-### api.setTitle(newTitle, threadID, [callback])
+### api.setTitle(newTitle, threadID[, callback])
 
 Sets the title of the group chat with thread id `threadID` to `newTitle`.
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,27 @@ _Disclaimer_: We are not responsible if your account gets banned for spammy acti
 See [below](#projects-using-this-api) for projects using this API.
 
 ## Install
+If you just want to use facebook-chat-api, you should use this command:
 ```bash
 npm install facebook-chat-api
+```
+It will download facebook-chat-api from NPM repositories
+
+### Bleeding edge
+If you want to use bleeding edge (directly from github) to test new features or submit bug report, this is the command for you:
+```bash
+npm install Schmavery/facebook-chat-api
 ```
 
 ## Example Usage
 ```javascript
-var login = require("facebook-chat-api");
+const login = require("facebook-chat-api");
 
 // Create simple echo bot
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+login({email: "FB_EMAIL", password: "FB_PASSWORD"}, (err, api) => {
     if(err) return console.error(err);
 
-    api.listen(function callback(err, message) {
+    api.listen((err, message) => {
         api.sendMessage(message.body, message.threadID);
     });
 });
@@ -37,9 +45,10 @@ Result:
 * [`api.changeArchivedStatus`](DOCS.md#changeArchivedStatus)
 * [`api.changeBlockedStatus`](DOCS.md#changeBlockedStatus)
 * [`api.changeGroupImage`](DOCS.md#changeGroupImage)
+* [`api.changeNickname`](DOCS.md#changeNickname)
 * [`api.changeThreadColor`](DOCS.md#changeThreadColor)
 * [`api.changeThreadEmoji`](DOCS.md#changeThreadEmoji)
-* [`api.changeNickname`](DOCS.md#changeNickname)
+* [`api.createPoll`](DOCS.md#createPoll)
 * [`api.deleteMessage`](DOCS.md#deleteMessage)
 * [`api.deleteThread`](DOCS.md#deleteThread)
 * [`api.getAppState`](DOCS.md#getAppState)
@@ -80,27 +89,51 @@ __Tip__: to find your own ID, you can look inside the cookies. The `userID` is u
 
 __Example (Basic Message)__
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const login = require("facebook-chat-api");
+
+login({email: "FB_EMAIL", password: "FB_PASSWORD"}, (err, api) => {
     if(err) return console.error(err);
 
-    var yourID = 0000000000000;
-    var msg = {body: "Hey!"};
+    var yourID = "000000000000000";
+    var msg = "Hey!";
     api.sendMessage(msg, yourID);
 });
 ```
 
 __Example (File upload)__
 ```js
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+const login = require("facebook-chat-api");
+
+login({email: "FB_EMAIL", password: "FB_PASSWORD"}, (err, api) => {
     if(err) return console.error(err);
 
     // Note this example uploads an image called image.jpg
-    var yourID = 0000000000000;
+    var yourID = "000000000000000";
     var msg = {
-      body: "Hey!",
-      attachment: fs.createReadStream(__dirname + '/image.jpg')
+        body: "Hey!",
+        attachment: fs.createReadStream(__dirname + '/image.jpg')
     }
     api.sendMessage(msg, yourID);
+});
+```
+
+------------------------------------
+### Saving session.
+
+To avoid logging in every time you should save AppState (cookies etc.) to a file, then you can use it without having password in your scripts.
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+var credentials = {email: "FB_EMAIL", password: "FB_PASSWORD"};
+
+login(credentials, (err, api) => {
+    if(err) return console.error(err);
+
+    fs.writeFileSync('appstate.json', JSON.stringify(api.getAppState()));
 });
 ```
 
@@ -109,36 +142,39 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 ### Listening to a chat
 #### api.listen(callback)
 
-Listen watches for messages sent in a chat. By default this won't receive events (joining/leaving a chat, title change etc...) but it can be activated with `api.setOptions({listenEvents: true})`. This will by default ignore messages sent by the current account, you can enable listening to your own messages with `api.setOptions({selfListen: true})`.
+Listen watches for messages sent in a chat. By default this won't receive events (joining/leaving a chat, title change etc…) but it can be activated with `api.setOptions({listenEvents: true})`. This will by default ignore messages sent by the current account, you can enable listening to your own messages with `api.setOptions({selfListen: true})`.
 
 __Example__
 
 ```js
-// Simple echo bot. He'll repeat anything that you say.
-// Will stop when you say '/stop'
+const fs = require("fs");
+const login = require("facebook-chat-api");
 
-login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api) {
+// Simple echo bot. It will repeat everything that you say.
+// Will stop when you say '/stop'
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
     if(err) return console.error(err);
 
     api.setOptions({listenEvents: true});
 
-    var stopListening = api.listen(function(err, event) {
+    var stopListening = api.listen((err, event) => {
         if(err) return console.error(err);
 
+        api.markAsRead(event.threadID, (err) => {
+            if(err) console.error(err);
+        });
+
         switch(event.type) {
-          case "message":
-            if(event.body === '/stop') {
-              api.sendMessage("Goodbye...", event.threadID);
-              return stopListening();
-            }
-            api.markAsRead(event.threadID, function(err) {
-              if(err) console.log(err);
-            });
-            api.sendMessage("TEST BOT: " + event.body, event.threadID);
-            break;
-          case "event":
-            console.log(event);
-            break;
+            case "message":
+                if(event.body === '/stop') {
+                    api.sendMessage("Goodbye…", event.threadID);
+                    return stopListening();
+                }
+                api.sendMessage("TEST BOT: " + event.body, event.threadID);
+                break;
+            case "event":
+                console.log(event);
+                break;
         }
     });
 });
@@ -161,7 +197,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 5. Do you support sending messages as a page?
 > Yes, set the pageID option on login (this doesn't work if you set it using api.setOptions, it affects the login process).
 > ```js
-> login(credentials, {pageID: xxxxx}, function(api) { ... }
+> login(credentials, {pageID: "000000000000000"}, (err, api) => { … }
 > ```
 
 6. I'm getting some crazy weird syntax error like `SyntaxError: Unexpected token [`!!!
@@ -171,7 +207,7 @@ login({email: "FB_EMAIL", password: "FB_PASSWORD"}, function callback (err, api)
 > You can use `api.setOptions` to silence the logging. You get the `api` object from `login` (see example above). Do
 > ```js
 > api.setOptions({
->   logLevel: "silent"
+>     logLevel: "silent"
 > });
 > ```
 


### PR DESCRIPTION
* Sort api functions alphabetically
* Add example how to use Github version (a.k.a _Bleeding Edge_) of facebook-chat-api instead of NPM version (_stable_)
* Change examples to use _appState_ instead of _email_+_password_ login
  (it is easier to use, you only have to login once and you don't have to put your password in every source file…)
* Add
  ```js
  const fs = require("fs");
  const login = require("facebook-chat-api");
  ```
  to examples where it was missing
* Some blocks of code were using 2 spaces as indentation - changed to 4 spaces, to match the rest
* change callbacks in examples from these inconsistent forms:
  * `function callback(err, api){}`
  * `function callback (err, api) {}`
  * `function(err, api) {}`
  * `function (err, api) {}`
  (and few other)
  to a single, simpler form:
  * `(err, api) => {}`.
* change `(…, [callback])` to `(…[, callback])`
* many other little fixes. (e.g. `callback(err)` where it should be `console.error(err)`)