### PR TITLE
Consistent log prefixes and messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,19 @@ var utils = require("./utils");
 var cheerio = require("cheerio");
 var log = require("npmlog");
 
+var defaultLogRecordSize = 100;
+log.maxRecordSize = defaultLogRecordSize;
+
 function setOptions(globalOptions, options) {
   Object.keys(options).map(function(key) {
     switch (key) {
       case 'logLevel':
         log.level = options.logLevel;
         globalOptions.logLevel = options.logLevel;
+        break;
+      case 'logRecordSize':
+        log.maxRecordSize = options.logRecordSize;
+        globalOptions.logRecordSize = options.logRecordSize;
         break;
       case 'selfListen':
         globalOptions.selfListen = options.selfListen;
@@ -424,6 +431,7 @@ function login(loginData, options, callback) {
     listenEvents: false,
     updatePresence: false,
     forceLogin: false,
+    logRecordSize: defaultLogRecordSize
   };
 
   setOptions(globalOptions, options);

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function setOptions(globalOptions, options) {
         globalOptions.forceLogin = options.forceLogin;
         break;
       default:
-        log.warn('Unrecognized option given to setOptions', key);
+        log.warn("setOptions", "Unrecognized option given to setOptions: " + key);
         break;
     }
   });
@@ -43,7 +43,7 @@ function buildAPI(globalOptions, html, jar) {
   }
 
   var userID = maybeCookie[0].cookieString().split("=")[1].toString();
-  log.info("Logged in");
+  log.info("login", "Logged in");
 
   var clientID = (Math.random() * 2147483648 | 0).toString(16);
 
@@ -147,7 +147,7 @@ function makeLogin(jar, email, password, loginOptions, callback) {
     });
     // ---------- Very Hacky Part Ends -----------------
 
-    log.info("Logging in...");
+    log.info("login", "Logging in...");
     return utils
       .post("https://www.facebook.com/login.php?login_attempt=1&lwv=110", jar, form)
       .then(utils.saveCookies(jar))
@@ -309,13 +309,13 @@ function loginHelper(appState, email, password, globalOptions, callback) {
       var form = {
         reason: 6
       };
-      log.info('Request to reconnect');
+      log.info("login", 'Request to reconnect');
       return defaultFuncs
         .get("https://www.facebook.com/ajax/presence/reconnect.php", ctx.jar, form)
         .then(utils.saveCookies(ctx.jar));
     })
     .then(function(res) {
-      log.info('Request to pull 1');
+      log.info("login", 'Request to pull 1');
       var form = {
         channel : 'p_' + ctx.userID,
         seq : 0,
@@ -367,7 +367,7 @@ function loginHelper(appState, email, password, globalOptions, callback) {
         sticky_pool: resData.lb_info.pool,
       };
 
-      log.info("Request to pull 2");
+      log.info("login", "Request to pull 2");
       return utils
         .get("https://0-edge-chat.facebook.com/pull", ctx.jar, form)
         .then(utils.saveCookies(ctx.jar));
@@ -378,7 +378,7 @@ function loginHelper(appState, email, password, globalOptions, callback) {
         'folders[0]': 'inbox',
         'last_action_timestamp' : '0'
       };
-      log.info("Request to thread_sync");
+      log.info("login", "Request to thread_sync");
 
       return defaultFuncs
         .post("https://www.facebook.com/ajax/mercury/thread_sync.php", ctx.jar, form)
@@ -404,11 +404,11 @@ function loginHelper(appState, email, password, globalOptions, callback) {
   // At the end we call the callback or catch an exception
   mainPromise
     .then(function() {
-      log.info('Done logging in.');
+      log.info("login", 'Done logging in.');
       return callback(null, api);
     })
     .catch(function(e) {
-      log.error("Error in login:", e.error || e);
+      log.error("login", e.error || e);
       callback(e);
     });
 }

--- a/src/addUserToGroup.js
+++ b/src/addUserToGroup.js
@@ -70,7 +70,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       return callback();
     })
     .catch(function(err) {
-      log.error("ERROR in addUserToGroup --> ", err);
+      log.error("addUserToGroup", err);
       return callback(err);
     });
   };

--- a/src/changeArchivedStatus.js
+++ b/src/changeArchivedStatus.js
@@ -30,7 +30,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in archiveThread", err);
+        log.error("changeArchivedStatus", err);
         return callback(err);
       });
   };

--- a/src/changeBlockedStatus.js
+++ b/src/changeBlockedStatus.js
@@ -30,7 +30,7 @@ module.exports = function (defaultFuncs, api, ctx) {
             })
         })
         .catch(function (err) {
-          log.error("Error in changeBlockedStatus", err);
+          log.error("changeBlockedStatus", err);
           return callback(err);
         });
     }
@@ -48,7 +48,7 @@ module.exports = function (defaultFuncs, api, ctx) {
           return callback();
         })
         .catch(function (err) {
-          log.error("Error in changeBlockedStatus", err);
+          log.error("changeBlockedStatus", err);
           return callback(err);
         });
 

--- a/src/changeGroupImage.js
+++ b/src/changeGroupImage.js
@@ -31,7 +31,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         callback(null, resData);
       })
       .catch(function(err) {
-        log.error("Error in handleUpload", err);
+        log.error("handleUpload", err);
         return callback(err);
       });
   }
@@ -99,7 +99,7 @@ module.exports = function(defaultFuncs, api, ctx) {
           return callback();
         })
         .catch(function(err) {
-          log.error("Error in uploading group image", err);
+          log.error("changeGroupImage", err);
           return callback(err);
         });
 

--- a/src/changeNickname.js
+++ b/src/changeNickname.js
@@ -30,7 +30,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in changeNickname", err);
+        log.error("changeNickname", err);
         return callback(err);
       });
   };

--- a/src/changeThreadColor.js
+++ b/src/changeThreadColor.js
@@ -27,7 +27,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in changeThreadColor", err);
+        log.error("changeThreadColor", err);
         return callback(err);
       });
   };

--- a/src/changeThreadEmoji.js
+++ b/src/changeThreadEmoji.js
@@ -27,7 +27,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in changeThreadEmoji", err);
+        log.error("changeThreadEmoji", err);
         return callback(err);
       });
   };

--- a/src/createPoll.js
+++ b/src/createPoll.js
@@ -42,7 +42,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in createPoll", err);
+        log.error("createPoll", err);
         return callback(err);
       });
   };

--- a/src/deleteMessage.js
+++ b/src/deleteMessage.js
@@ -32,7 +32,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in deleteMessage", err);
+        log.error("deleteMessage", err);
         return callback(err);
       });
   };

--- a/src/deleteThread.js
+++ b/src/deleteThread.js
@@ -32,7 +32,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in deleteThread", err);
+        log.error("deleteThread", err);
         return callback(err);
       });
   };

--- a/src/getFriendsList.js
+++ b/src/getFriendsList.js
@@ -58,7 +58,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         callback(null, formatData(resData.payload));
       })
       .catch(function(err) {
-        log.error("Error in getFriendsList", err);
+        log.error("getFriendsList", err);
         return callback(err);
       });
   };

--- a/src/getThreadHistory.js
+++ b/src/getThreadHistory.js
@@ -57,7 +57,7 @@ module.exports = function(defaultFuncs, api, ctx) {
           });
         })
         .catch(function(err) {
-          log.error("Error in getThreadHistory", err);
+          log.error("getThreadHistory", err);
           return callback(err);
         });
     });

--- a/src/getThreadInfo.js
+++ b/src/getThreadInfo.js
@@ -52,7 +52,7 @@ module.exports = function(defaultFuncs, api, ctx) {
           callback(null, info);
 
         }).catch(function(err) {
-          log.error("Error in getThreadInfo", err);
+          log.error("getThreadInfo", err);
           return callback(err);
         });
     });

--- a/src/getThreadList.js
+++ b/src/getThreadList.js
@@ -52,11 +52,11 @@ module.exports = function(defaultFuncs, api, ctx) {
         if (resData.error) {
           throw resData;
         }
-        log.verbose("Response in getThreadList: " + JSON.stringify(resData.payload.threads));
+        log.verbose("getThreadList", JSON.stringify(resData.payload.threads));
         return callback(null, (resData.payload.threads || []).map(utils.formatThread));
       })
       .catch(function(err) {
-        log.error("Error in getThreadList", err);
+        log.error("getThreadList", err);
         return callback(err);
       });
   };

--- a/src/getUserID.js
+++ b/src/getUserID.js
@@ -48,7 +48,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         callback(null, data.map(formatData));
       })
       .catch(function(err) {
-        log.error("Error in getUserID", err);
+        log.error("getUserID", err);
         return callback(err);
       });
   };

--- a/src/getUserInfo.js
+++ b/src/getUserInfo.js
@@ -49,7 +49,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       return callback(null, formatData(resData.payload.profiles));
     })
     .catch(function(err) {
-      log.error("Error in getUserInfo", err);
+      log.error("getUserInfo", err);
       return callback(err);
     });
   };

--- a/src/handleMessageRequest.js
+++ b/src/handleMessageRequest.js
@@ -40,7 +40,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in handleMessageRequest", err);
+        log.error("handleMessageRequest", err);
         return callback(err);
       });
   };

--- a/src/listen.js
+++ b/src/listen.js
@@ -68,7 +68,7 @@ module.exports = function(defaultFuncs, api, ctx) {
     .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
     .then(function(resData) {
       var now = Date.now();
-      log.info("Got answer in ", now - tmpPrev);
+      log.info("listen", "Got answer in " + now - tmpPrev);
       tmpPrev = now;
 
       if(resData && resData.t === "lb") {
@@ -227,9 +227,9 @@ module.exports = function(defaultFuncs, api, ctx) {
     })
     .catch(function(err) {
       if (err.code === 'ETIMEDOUT') {
-        log.info("Suppressed timeout error.");
+        log.info("listen", "Suppressed timeout error.");
       } else {
-        log.error("ERROR in listen --> ", err);
+        log.error("listen", err);
         globalCallback(err);
       }
       if (currentlyRunning) {

--- a/src/logout.js
+++ b/src/logout.js
@@ -44,11 +44,11 @@ module.exports = function(defaultFuncs, api, ctx) {
       })
       .then(function() {
         ctx.loggedIn = false;
-        log.info("Logged out successfully.");
+        log.info("logout", "Logged out successfully.");
         callback();
       })
       .catch(function(err) {
-        log.error("Error in logout", err);
+        log.error("logout", err);
         return callback(err);
       });
   };

--- a/src/markAsRead.js
+++ b/src/markAsRead.js
@@ -28,7 +28,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in markAsRead", err);
+        log.error("markAsRead", err);
         return callback(err);
       });
   };

--- a/src/muteThread.js
+++ b/src/muteThread.js
@@ -27,7 +27,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in muteThread", err);
+        log.error("muteThread", err);
         return callback(err);
       });
   };

--- a/src/removeUserFromGroup.js
+++ b/src/removeUserFromGroup.js
@@ -38,7 +38,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("ERROR in removeUserFromGroup --> ", err);
+        log.error("removeUserFromGroup", err);
         return callback(err);
       });
   };

--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -47,7 +47,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         callback(null, resData);
       })
       .catch(function(err) {
-        log.error("Error in uploadAttachment", err);
+        log.error("uploadAttachment", err);
         return callback(err);
       });
   }
@@ -74,7 +74,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         callback(null, resData.payload.share_data.share_params);
       })
       .catch(function(err) {
-        log.error("Error in getUrl", err);
+        log.error("getUrl", err);
         return callback(err);
       });
   }
@@ -91,7 +91,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       }
       form['specific_to_list[' + (threadID.length) + ']'] = "fbid:" + ctx.userID;
       form['client_thread_id'] = "root:" + messageAndOTID;
-      log.info("Sending message to multiple users: " + threadID);
+      log.info("sendMessage", "Sending message to multiple users: " + threadID);
     } else {
       // This means that threadID is the id of a user, and the chat
       // is a single person chat
@@ -125,7 +125,8 @@ module.exports = function(defaultFuncs, api, ctx) {
 
         if (resData.error) {
           if (resData.error === 1545012) {
-            log.warn("Got error 1545012. This might mean that you're not part of the conversation " + threadID);
+            log.warn("sendMessage", "Got error 1545012. This might mean that you're not part of the conversation "
+              + threadID);
           }
           return callback(resData);
         }
@@ -140,7 +141,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback(null, messageInfo);
       })
       .catch(function(err) {
-        log.error("ERROR in sendMessage --> ", err);
+        log.error("sendMessage", err);
         return callback(err);
       });
   }

--- a/src/sendTypingIndicator.js
+++ b/src/sendTypingIndicator.js
@@ -35,7 +35,7 @@ module.exports = function(defaultFuncs, api, ctx) {
           return callback();
         })
         .catch(function(err) {
-          log.error("Error in sendTypingIndicator", err);
+          log.error("sendTypingIndicator", err);
           return callback(err);
         });
     });

--- a/src/setTitle.js
+++ b/src/setTitle.js
@@ -61,7 +61,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         return callback();
       })
       .catch(function(err) {
-        log.error("Error in setTitle", err);
+        log.error("setTitle", err);
         return callback(err);
       });
   };

--- a/utils.js
+++ b/utils.js
@@ -575,9 +575,9 @@ function makeDefaults(html, userID) {
 function parseAndCheckLogin(jar, defaultFuncs) {
   return function(data) {
     return bluebird.try(function() {
-      log.verbose("parseAndCheckLogin: " + data.body);
+      log.verbose("parseAndCheckLogin", data.body);
       if (data.statusCode >= 500 && data.statusCode < 600) {
-        log.warn("parseAndCheckLogin: Got status code " + data.statusCode + " retrying...");
+        log.warn("parseAndCheckLogin", "Got status code " + data.statusCode + " retrying...");
         var url = data.request.uri.protocol + "//" + data.request.uri.hostname + data.request.uri.pathname;
         if (data.request.headers['Content-Type'].split(";")[0] === "multipart/form-data") {
           return defaultFuncs


### PR DESCRIPTION
Throughout the library there were log npmlog calls with a missing prefix (i.e. passing the message as the prefix). Fixed that.

Also removed redundant "Error in someFunction" in the prefix/message since this information is present in the function call (e.g. log.error, log.warn)