### PR TITLE
Fix NaN in listen logs

### DIFF
--- a/src/listen.js
+++ b/src/listen.js
@@ -68,7 +68,7 @@ module.exports = function(defaultFuncs, api, ctx) {
     .then(utils.parseAndCheckLogin(ctx.jar, defaultFuncs))
     .then(function(resData) {
       var now = Date.now();
-      log.info("listen", "Got answer in " + now - tmpPrev);
+      log.info("listen", "Got answer in " + (now - tmpPrev));
       tmpPrev = now;
 
       if(resData && resData.t === "lb") {


### PR DESCRIPTION
Without parentheses around the calculation, string logic evaluates to NaN in the logging from listen.js:
![NaN](https://cloud.githubusercontent.com/assets/6151790/22962284/f715de7e-f319-11e6-952f-6fe8e2448c4b.png)