### PR TITLE
Adding chatproxy_presence aka buddyList

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -652,11 +652,15 @@ Difference between `"read_receipt"` and `"read"`:
 - `"read"` event triggers when the user read other people's messages.
 
 <a name="presence" />
-If enabled through [setOptions](#setOptions), this will also return presence, (`type` will be `"presence"`), which is the online status of the user's friends. The object given to the callback will have the following fields:
+If enabled through [setOptions](#setOptions), this will also return presence or buddyList, (`type` will be `"presence"` or `"buddyList"`), which is the online status of the user's friends. The object given for presence to the callback will have the following fields:
 - `type`: The string "presence".
 - `timestamp`: How old the information is.
 - `userID`: The ID of the user whose status this packet is describing
 - `statuses`: The online status of the user. `0` means the user is idle (away for 2 minutes) and `2` means the user is online.
+
+The object given for buddyList to the callback will have the following fields:
+- `type`: The string "buddyList".
+- `buddyList`: array with (almost) all users presences (array fields are same as in `presence`, so `timestamp`, `userID` and `statuses`)
 
 __Example__
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -652,15 +652,11 @@ Difference between `"read_receipt"` and `"read"`:
 - `"read"` event triggers when the user read other people's messages.
 
 <a name="presence" />
-If enabled through [setOptions](#setOptions), this will also return presence or buddyList, (`type` will be `"presence"` or `"buddyList"`), which is the online status of the user's friends. The object given for presence to the callback will have the following fields:
+If enabled through [setOptions](#setOptions), this will also return presence, (`type` will be `"presence"`, which is the online status of the user's friends. The object given for presence to the callback will have the following fields:
 - `type`: The string "presence".
 - `timestamp`: How old the information is.
 - `userID`: The ID of the user whose status this packet is describing
 - `statuses`: The online status of the user. `0` means the user is idle (away for 2 minutes) and `2` means the user is online (we don't know what 1 or above 2 is...).
-
-The object given for buddyList to the callback will have the following fields:
-- `type`: The string "buddyList".
-- `buddyList`: array with (almost) all users presences (array fields are same as in `presence`, so `timestamp`, `userID` and `statuses`)
 
 __Example__
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -651,9 +651,9 @@ Difference between `"read_receipt"` and `"read"`:
 - `"read_receipt"` event triggers when other people read the user's messages.
 - `"read"` event triggers when the user read other people's messages.
 
-<a name="presence" />
-If enabled through [setOptions](#setOptions), this will also return presence, (`type` will be `"presence"`, which is the online status of the user's friends. The object given for presence to the callback will have the following fields:
-- `type`: The string "presence".
+<a name="presence"></a>
+If enabled through [setOptions](#setOptions), `message` could also be a presence object, (`type` will be `"presence"`), which is the online status of the user's friends. That object given to the callback will have the following fields:
+- `type`: The string `"presence"`.
 - `timestamp`: How old the information is.
 - `userID`: The ID of the user whose status this packet is describing
 - `statuses`: The online status of the user. `0` means the user is idle (away for 2 minutes) and `2` means the user is online (we don't know what 1 or above 2 is...).

--- a/src/listen.js
+++ b/src/listen.js
@@ -118,12 +118,35 @@ module.exports = function(defaultFuncs, api, ctx) {
 
               return globalCallback(null, utils.formatTyp(v));
               break;
+            case 'chatproxy-presence':
+              // TODO: what happens when you're logged in as a page?
+              if(!ctx.globalOptions.updatePresence) {
+                return;
+              }
+              
+              var buddyList = [];
+              var presence = null;
+              
+              for(var userID in v.buddyList) {
+                presence = utils.formatProxyPresence(v.buddyList[userID], userID);
+                if(presence != null)
+                {
+                  buddyList.push(presence);
+                }
+              }
+              
+              if(ctx.loggedIn) {
+                return globalCallback(null, {
+                  type: "buddyList",
+                  buddyList: buddyList
+                });
+              }
+              break;
             case 'buddylist_overlay':
               // TODO: what happens when you're logged in as a page?
               if(!ctx.globalOptions.updatePresence) {
                 return;
               }
-
               // There should be only one key inside overlay
               Object.keys(v.overlay).map(function(userID) {
                 var formattedPresence = utils.formatPresence(v.overlay[userID], userID);

--- a/src/listen.js
+++ b/src/listen.js
@@ -123,23 +123,18 @@ module.exports = function(defaultFuncs, api, ctx) {
                 return;
               }
               
-              var buddyList = [];
-              var presence = null;
               
-              for(var userID in v.buddyList) {
-                presence = utils.formatProxyPresence(v.buddyList[userID], userID);
-                if(presence != null)
-                {
-                  buddyList.push(presence);
+              if (ctx.loggedIn) {
+                for(var userID in v.buddyList) {
+                  var formattedPresence = utils.formatProxyPresence(v.buddyList[userID], userID);
+                  if(formattedPresence != null)
+                  {
+                    globalCallback(null, formattedPresence);
+                  }
                 }
+                return;
               }
               
-              if(ctx.loggedIn) {
-                return globalCallback(null, {
-                  type: "buddyList",
-                  buddyList: buddyList
-                });
-              }
               break;
             case 'buddylist_overlay':
               // TODO: what happens when you're logged in as a page?

--- a/utils.js
+++ b/utils.js
@@ -696,6 +696,15 @@ function getType(obj) {
   return Object.prototype.toString.call(obj).slice(8, -1);
 }
 
+function formatProxyPresence(presence, userID) {
+  if(presence.lat === undefined) return null;
+  return {
+    timestamp: presence.lat * 1000,
+    userID: userID,
+    statuses: presence.p === undefined ? 0 : presence.p
+  };
+}
+
 function formatPresence(presence, userID) {
   return {
     type: "presence",
@@ -733,6 +742,7 @@ module.exports = {
   formatMessage: formatMessage,
   formatDeltaMessage: formatDeltaMessage,
   formatEvent: formatEvent,
+  formatProxyPresence: formatProxyPresence,
   formatPresence: formatPresence,
   formatTyp: formatTyp,
   formatCookie: formatCookie,

--- a/utils.js
+++ b/utils.js
@@ -712,6 +712,7 @@ function getType(obj) {
 function formatProxyPresence(presence, userID) {
   if(presence.lat === undefined) return null;
   return {
+    type: "presence",
     timestamp: presence.lat * 1000,
     userID: userID,
     statuses: presence.p === undefined ? 0 : presence.p


### PR DESCRIPTION
Returning a list of people (similar to presence) with type of status and timestamp. This event trigger on first pull and in some intervals (server-side, cannot be triggered manually)

BTW. both (chatproxy_presence and buddylist_overlay) returning a field "vc" (in chatproxy_presence).
As far I investigated it have something with status "Active on Messenger"