### PR TITLE
Strip 'fbid:' from message senderID in util.js

### DIFF
--- a/src/getFriendsList.js
+++ b/src/getFriendsList.js
@@ -27,7 +27,7 @@ function formatData(obj) {
       alternateName: user.alternateName,
       firstName: user.firstName,
       gender: GENDERS[user.gender],
-      userID: user.id.toString(),
+      userID: utils.formatID(user.id.toString()),
       isFriend: (user.is_friend != null && user.is_friend) ? true : false,
       fullName: user.name,
       profilePicture: user.thumbSrc,

--- a/src/getUserID.js
+++ b/src/getUserID.js
@@ -5,7 +5,7 @@ var log = require("npmlog");
 
 function formatData(data) {
   return {
-    userID: data.uid.toString(),
+    userID: utils.formatID(data.uid.toString()),
     photoUrl: data.photo,
     indexRank: data.index_rank,
     name: data.text,

--- a/utils.js
+++ b/utils.js
@@ -384,7 +384,7 @@ function formatMessage(m) {
   var obj = {
     type: "message",
     senderName: originalMessage.sender_name,
-    senderID: originalMessage.sender_fbid.toString(),
+    senderID: originalMessage.sender_fbid.toString().substr(originalMessage.sender_fbid.toString().indexOf(':')+1), //Strip "fbid:"
     participantNames: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_names : [originalMessage.sender_name.split(' ')[0]]),
     participantIDs: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_ids.map(function(v) {return v.toString();}) : [originalMessage.sender_fbid]),
     body: originalMessage.body,

--- a/utils.js
+++ b/utils.js
@@ -369,9 +369,9 @@ function formatDeltaMessage(m){
   var md = m.delta.messageMetadata;
   return {
     type: "message",
-    senderID: md.actorFbId,
+    senderID: formatID(md.actorFbId),
     body: m.delta.body,
-    threadID: (md.threadKey.threadFbId || md.threadKey.otherUserFbId).toString(),
+    threadID: formatID((md.threadKey.threadFbId || md.threadKey.otherUserFbId).toString()),
     messageID: md.messageId,
     attachments: (m.delta.attachments || []).map(v => _formatAttachment(v)),
     timestamp: md.timestamp,
@@ -380,7 +380,11 @@ function formatDeltaMessage(m){
 }
 
 function formatID(id){
-  return id.replace(/(fb)?id[:.]/, "");
+  if(id != undefined && id != null){
+    return id.replace(/(fb)?id[:.]/, "");
+  }else{
+    return id;
+  }
 }
 
 function formatMessage(m) {
@@ -453,7 +457,7 @@ function formatEvent(m) {
 
   return {
     type: "event",
-    threadID: m.messageMetadata.threadKey.threadFbId || m.messageMetadata.threadKey.otherUserFbId,
+    threadID: formatID(m.messageMetadata.threadKey.threadFbId || m.messageMetadata.threadKey.otherUserFbId),
     logMessageType: logMessageType,
     logMessageData: logMessageData,
     logMessageBody: m.messageMetadata.adminText,
@@ -465,7 +469,7 @@ function formatTyp(event) {
   return {
     isTyping: !!event.st,
     from: event.from.toString(),
-    threadID: (event.to || event.thread_fbid || event.from).toString(),
+    threadID: formatID((event.to || event.thread_fbid || event.from).toString()),
     // When receiving typ indication from mobile, `from_mobile` isn't set.
     // If it is, we just use that value.
     fromMobile: event.hasOwnProperty('from_mobile') ? event.from_mobile : true,
@@ -480,7 +484,7 @@ function formatDeltaReadReceipt(delta) {
   return {
     reader: (delta.threadKey.otherUserFbId || delta.actorFbId).toString(),
     time: delta.actionTimestampMs,
-    threadID: (delta.threadKey.otherUserFbId || delta.threadKey.threadFbId).toString(),
+    threadID: formatID((delta.threadKey.otherUserFbId || delta.threadKey.threadFbId).toString()),
     type: 'read_receipt'
   };
 }
@@ -489,14 +493,14 @@ function formatReadReceipt(event) {
   return {
     reader: event.reader.toString(),
     time: event.time,
-    threadID: (event.thread_fbid || event.reader).toString(),
+    threadID: formatID((event.thread_fbid || event.reader).toString()),
     type: 'read_receipt',
   };
 }
 
 function formatRead(event) {
   return {
-    threadID: ((event.chat_ids && event.chat_ids[0]) || (event.thread_fbids && event.thread_fbids[0])).toString(),
+    threadID: formatID(((event.chat_ids && event.chat_ids[0]) || (event.thread_fbids && event.thread_fbids[0])).toString()),
     time: event.timestamp,
     type: 'read'
   };
@@ -694,9 +698,9 @@ function formatCookie(arr, url) {
 
 function formatThread(data) {
   return {
-    threadID: data.thread_fbid.toString(),
-    participants: data.participants.map(function(v) { return v.replace('fbid:', ''); }),
-    participantIDs: data.participants.map(function(v) { return v.replace('fbid:', ''); }),
+    threadID: formatID(data.thread_fbid.toString()),
+    participants: data.participants.map(function(v) { return formatID(v.replace('fbid:', '')); }),
+    participantIDs: data.participants.map(function(v) { return formatID(v.replace('fbid:', '')); }),
     formerParticipants: data.former_participants,
     name: data.name,
     nicknames: data.custom_nickname,
@@ -712,7 +716,7 @@ function formatThread(data) {
     muteSettings: data.muteSettings,
     isCanonicalUser: data.is_canonical_user,
     isCanonical: data.is_canonical,
-    canonicalFbid: data.canonical_fbid,
+    canonicalFbid: formatID(data.canonical_fbid),
     isSubscribed: data.is_subscribed,
     rootMessageThreadingID: data.root_message_threading_id,
     folder: data.folder,

--- a/utils.js
+++ b/utils.js
@@ -369,7 +369,7 @@ function formatDeltaMessage(m){
   var md = m.delta.messageMetadata;
   return {
     type: "message",
-    senderID: formatID(md.actorFbId),
+    senderID: formatID(md.actorFbId.toString()),
     body: m.delta.body,
     threadID: formatID((md.threadKey.threadFbId || md.threadKey.otherUserFbId).toString()),
     messageID: md.messageId,
@@ -396,7 +396,7 @@ function formatMessage(m) {
     participantNames: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_names : [originalMessage.sender_name.split(' ')[0]]),
     participantIDs: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_ids.map(function(v) {return formatID(v.toString());}) : [formatID(originalMessage.sender_fbid)]),
     body: originalMessage.body,
-    threadID: formatID(originalMessage.thread_fbid || originalMessage.other_user_fbid),
+    threadID: formatID((originalMessage.thread_fbid || originalMessage.other_user_fbid).toString()),
     threadName: (originalMessage.group_thread_info ? originalMessage.group_thread_info.name : originalMessage.sender_name),
     location: originalMessage.coordinates ? originalMessage.coordinates : null,
     messageID: originalMessage.mid ? originalMessage.mid.toString() : originalMessage.message_id,
@@ -457,7 +457,7 @@ function formatEvent(m) {
 
   return {
     type: "event",
-    threadID: formatID(m.messageMetadata.threadKey.threadFbId || m.messageMetadata.threadKey.otherUserFbId),
+    threadID: formatID((m.messageMetadata.threadKey.threadFbId || m.messageMetadata.threadKey.otherUserFbId).toString()),
     logMessageType: logMessageType,
     logMessageData: logMessageData,
     logMessageBody: m.messageMetadata.adminText,
@@ -699,15 +699,15 @@ function formatCookie(arr, url) {
 function formatThread(data) {
   return {
     threadID: formatID(data.thread_fbid.toString()),
-    participants: data.participants.map(function(v) { return formatID(v.replace('fbid:', '')); }),
-    participantIDs: data.participants.map(function(v) { return formatID(v.replace('fbid:', '')); }),
+    participants: data.participants.map(formatID),
+    participantIDs: data.participants.map(formatID),
     formerParticipants: data.former_participants,
     name: data.name,
     nicknames: data.custom_nickname,
     snippet: data.snippet,
     snippetHasAttachment: data.snippet_has_attachment,
     snippetAttachments: data.snippet_attachments,
-    snippetSender: (data.snippet_sender || '').replace('fbid:', ''),
+    snippetSender: formatID((data.snippet_sender || '').toString()),
     unreadCount: data.unread_count,
     messageCount: data.message_count,
     imageSrc: data.image_src,
@@ -716,7 +716,7 @@ function formatThread(data) {
     muteSettings: data.muteSettings,
     isCanonicalUser: data.is_canonical_user,
     isCanonical: data.is_canonical,
-    canonicalFbid: formatID(data.canonical_fbid),
+    canonicalFbid: formatID((data.canonical_fbid || '').toString()),
     isSubscribed: data.is_subscribed,
     rootMessageThreadingID: data.root_message_threading_id,
     folder: data.folder,
@@ -787,6 +787,7 @@ module.exports = {
   parseAndCheckLogin: parseAndCheckLogin,
   saveCookies: saveCookies,
   getType: getType,
+  formatID: formatID,
   formatMessage: formatMessage,
   formatDeltaMessage: formatDeltaMessage,
   formatEvent: formatEvent,

--- a/utils.js
+++ b/utils.js
@@ -379,16 +379,20 @@ function formatDeltaMessage(m){
   }
 }
 
+function formatID(id){
+  return id.replace(/(fb)?id[:.]/, "");
+}
+
 function formatMessage(m) {
   var originalMessage = m.message ? m.message : m;
   var obj = {
     type: "message",
     senderName: originalMessage.sender_name,
-    senderID: originalMessage.sender_fbid.toString().substr(originalMessage.sender_fbid.toString().indexOf(':')+1), //Strip "fbid:"
+    senderID: formatID(originalMessage.sender_fbid.toString()),
     participantNames: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_names : [originalMessage.sender_name.split(' ')[0]]),
-    participantIDs: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_ids.map(function(v) {return v.toString();}) : [originalMessage.sender_fbid]),
+    participantIDs: (originalMessage.group_thread_info ? originalMessage.group_thread_info.participant_ids.map(function(v) {return formatID(v.toString());}) : [formatID(originalMessage.sender_fbid)]),
     body: originalMessage.body,
-    threadID: originalMessage.tid && originalMessage.tid.split(".")[0] === "id" ? originalMessage.tid.split('.')[1] : originalMessage.thread_fbid || originalMessage.other_user_fbid,
+    threadID: formatID(originalMessage.thread_fbid || originalMessage.other_user_fbid),
     threadName: (originalMessage.group_thread_info ? originalMessage.group_thread_info.name : originalMessage.sender_name),
     location: originalMessage.coordinates ? originalMessage.coordinates : null,
     messageID: originalMessage.mid ? originalMessage.mid.toString() : originalMessage.message_id,


### PR DESCRIPTION
# Fix for [Issue 438](https://github.com/Schmavery/facebook-chat-api/issues/438)

This uses string functions substr and indexOf to strip `fbid:` from senderID as referred in my issue. 

This should be compatible whether the senderID has the `fbid:` prefix or not. If the senderID string does not have the prefix, it will do substr(0) which will not strip anything.

