### PR TITLE
Adding err to getThreadPictures callback

### DIFF
--- a/src/getThreadPictures.js
+++ b/src/getThreadPictures.js
@@ -42,7 +42,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         }));
       })
       .then(function(resData) {
-        callback(resData);
+        callback(null, resData);
       })
       .catch(function(err) {
         log.error("Error in getThreadPictures", err);


### PR DESCRIPTION
By documentation, there need to be `err` property