### PR TITLE
sendTypingIndicator: make callback optional

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -944,7 +944,7 @@ login({email: "EMAIL", password: "PASSWORD"}, (err, api) => {
 <a name="sendTypingIndicator"></a>
 ### api.sendTypingIndicator(threadID[, callback])
 
-Sends a "USERNAME is typing" indicator to other members of the thread indicated by threadID.  This indication will disappear after 30 second or when the `end` function is called. The `end` function is returned by `api.sendTypingIndicator`.
+Sends a "USERNAME is typing" indicator to other members of the thread indicated by `threadID`. This indication will disappear after 30 second or when the `end` function is called. The `end` function is returned by `api.sendTypingIndicator`.
 
 __Arguments__
 

--- a/src/sendTypingIndicator.js
+++ b/src/sendTypingIndicator.js
@@ -12,7 +12,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       thread: threadID
     };
 
-    // Check if thread is single person chat or group chat
+    // Check if thread is a single person chat or a group chat
     // More info on this is in api.sendMessage
     api.getUserInfo(threadID, function(err, res) {
       if (err) {
@@ -42,15 +42,24 @@ module.exports = function(defaultFuncs, api, ctx) {
   }
 
   return function sendTypingIndicator(threadID, callback) {
-    if(!callback) {
-      throw {error: "sendTypingIndicator: need callback"};
+    if (utils.getType(callback) !== 'Function' && utils.getType(callback) !== 'AsyncFunction') {
+      if (callback) {
+        log.warn("sendTypingIndicator", "callback is not a function - ignoring.");
+      }
+      callback = () => {};
     }
 
     makeTypingIndicator(true, threadID, callback);
 
-    // TODO: document that we return the stop/cancel functions now
     return function end(cb) {
-      makeTypingIndicator(false, threadID, cb || function() {});
+      if (utils.getType(cb) !== 'Function' && utils.getType(cb) !== 'AsyncFunction') {
+        if (cb) {
+          log.warn("sendTypingIndicator", "callback is not a function - ignoring.");
+        }
+        cb = () => {};
+      }
+
+      makeTypingIndicator(false, threadID, cb);
     };
   };
 };


### PR DESCRIPTION
I was getting this error:

```
Unhandled rejection TypeError: callback is not a function
    at /var/www/node/messenger/node_modules/facebook-chat-api/src/sendTypingIndicator.js:39:18
    at tryCatcher (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/promise.js:510:31)
    at Promise._settlePromiseAt (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/promise.js:584:18)
    at Promise._settlePromises (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/promise.js:700:14)
    at Async._drainQueue (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/var/www/node/messenger/node_modules/facebook-chat-api/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

when using:
```js
end = api.sendTypingIndicator(event.threadID, function() {});
// run some background process
api.sendMessage(msg, event.threadID, end);
```

and it turned out that `function end(cb)` was called with `cb` being an object instead of a function.