### PR TITLE
Fix inconsistencies between thread data in getThreadInfo and getThreadList

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -518,7 +518,7 @@ __Arguments__
 * `threadID`: A threadID corresponding to the target thread.
 * `callback(err, info)`: If `err` is `null`, `info` will contain the following propertis: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `nicknames`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID, emoji, color, lastReadTimestamp`.
 
-Some of the properties may be null if they are unset. E.g. `emoji`, `color`, `nicknames`, or `imageSrc`.
+Some of the properties may be null if they are unset. E.g. `emoji`, `color`, or `nicknames`.
 
 ---------------------------------------
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -516,7 +516,9 @@ Takes a threadID and a callback.  Works for both single-user and group threads.
 
 __Arguments__
 * `threadID`: A threadID corresponding to the target thread.
-* `callback(err, info)`: If `err` is `null`, `info` will contain `participantIDs`, `name`, `snippet`, `messageCount`, `emoji`, `nicknames`, and `color`.  The last three will be null if custom values are not set for the thread.
+* `callback(err, info)`: If `err` is `null`, `info` will contain the following propertis: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `nicknames`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID, emoji, color, lastReadTimestamp`.
+
+Some of the properties may be null if they are unset. E.g. `emoji`, `color`, `nicknames`, or `imageSrc`.
 
 ---------------------------------------
 
@@ -530,7 +532,9 @@ __Arguments__
 * `start`: Start index in the list of recently used threads.
 * `end`: End index.
 * `type`: Optional String, can be 'inbox', 'pending', or 'archived'. Inbox is default.
-* `callback(err, arr)`: A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of thread object containing the following properties: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `nicknames`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID`.
+* `callback(err, arr)`: A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of thread object containing the following properties: `threadID`, <del>`participants`</del>, `participantIDs`, `formerParticipants`, `name`, `nicknames`, `snippet`, `snippetHasAttachment`, `snippetAttachments`, `snippetSender`, `unreadCount`, `messageCount`, `imageSrc`, `timestamp`, `serverTimestamp`, `muteSettings`, `isCanonicalUser`, `isCanonical`, `canonicalFbid`, `isSubscribed`, `rootMessageThreadingID`, `folder`, `isArchived`, `recipientsLoadable`, `hasEmailParticipant`, `readOnly`, `canReply`, `composerEnabled`, `blockedParticipants`, `lastMessageID, emoji, color, lastReadTimestamp`.
+
+Some of the properties may be null if they are unset. E.g. `emoji`, `color`, `nicknames`, or `imageSrc`.
 
 ---------------------------------------
 

--- a/src/getThreadInfo.js
+++ b/src/getThreadInfo.js
@@ -39,17 +39,19 @@ module.exports = function(defaultFuncs, api, ctx) {
             };
           }
 
-          var info = {
-            participantIDs: threadData.participants.map(id => id.split(':').pop()),
-            name: userData != null && userData.name != null ? userData.name : threadData.name,
-            snippet: threadData.snippet,
-            messageCount: threadData.message_count,
-            emoji: threadData.custom_like_icon,
-            nicknames: threadData.custom_nickname,
-            color: threadData.custom_color,
-            lastReadTimestamp: threadData.last_read_timestamp,
-          };
-          callback(null, info);
+          // var info = {
+          //   participantIDs: threadData.participants.map(id => id.split(':').pop()),
+          //   name: userData != null && userData.name != null ? userData.name : threadData.name,
+          //   snippet: threadData.snippet,
+          //   messageCount: threadData.message_count,
+          //   emoji: threadData.custom_like_icon,
+          //   nicknames: threadData.custom_nickname,
+          //   color: threadData.custom_color,
+          //   lastReadTimestamp: threadData.last_read_timestamp,
+          // };
+          threadData.name = userData != null && userData.name != null ? userData.name : threadData.name;
+          
+          callback(null, utils.formatThread(threadData));
 
         }).catch(function(err) {
           log.error("getThreadInfo", err);

--- a/src/getThreadInfo.js
+++ b/src/getThreadInfo.js
@@ -40,7 +40,7 @@ module.exports = function(defaultFuncs, api, ctx) {
           }
           
           threadData.name = userData != null && userData.name != null ? userData.name : threadData.name;
-          threadData.imageSrc = userData != null && userData.thumbSrc != null ? userData.thumbSrc : threadData.imageSrc;
+          threadData.image_src = userData != null && userData.thumbSrc != null ? userData.thumbSrc : threadData.imageSrc;
 
           callback(null, utils.formatThread(threadData));
 

--- a/src/getThreadInfo.js
+++ b/src/getThreadInfo.js
@@ -40,6 +40,7 @@ module.exports = function(defaultFuncs, api, ctx) {
           }
           
           threadData.name = userData != null && userData.name != null ? userData.name : threadData.name;
+          threadData.imageSrc = userData != null && userData.thumbSrc != null ? userData.thumbSrc : threadData.imageSrc;
 
           callback(null, utils.formatThread(threadData));
 

--- a/src/getThreadInfo.js
+++ b/src/getThreadInfo.js
@@ -38,19 +38,9 @@ module.exports = function(defaultFuncs, api, ctx) {
               error: "ThreadData is null"
             };
           }
-
-          // var info = {
-          //   participantIDs: threadData.participants.map(id => id.split(':').pop()),
-          //   name: userData != null && userData.name != null ? userData.name : threadData.name,
-          //   snippet: threadData.snippet,
-          //   messageCount: threadData.message_count,
-          //   emoji: threadData.custom_like_icon,
-          //   nicknames: threadData.custom_nickname,
-          //   color: threadData.custom_color,
-          //   lastReadTimestamp: threadData.last_read_timestamp,
-          // };
-          threadData.name = userData != null && userData.name != null ? userData.name : threadData.name;
           
+          threadData.name = userData != null && userData.name != null ? userData.name : threadData.name;
+
           callback(null, utils.formatThread(threadData));
 
         }).catch(function(err) {

--- a/utils.js
+++ b/utils.js
@@ -779,7 +779,10 @@ function formatThread(data) {
     canReply: data.can_reply,
     composerEnabled: data.composer_enabled,
     blockedParticipants: data.blocked_participants,
-    lastMessageID: data.last_message_id
+    lastMessageID: data.last_message_id,
+    emoji: data.custom_like_icon,
+    color: data.custom_color,
+    lastReadTimestamp: data.last_read_timestamp
   };
 }
 


### PR DESCRIPTION
# Fixing thread data inconsistencies 

The data you get from threads in `getThreadInfo` and `getThreadList` are wildly different. This PR adds the data in `getThreadInfo` that wasn't into `utils.formatThread` and applies `utils.formatThread` to the thread in `getThreadInfo` so that you could get the same data you get from threads in `getThreadList` in `getThreadInfo`.