### PR TITLE
Utility function for getting the image URL for a Messenger-style emoji

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -14,6 +14,7 @@
 * [`api.forwardAttachment`](#forwardAttachment)
 * [`api.getAppState`](#getAppState)
 * [`api.getCurrentUserID`](#getCurrentUserID)
+* [`api.getEmojiUrl`](#getEmojiUrl)
 * [`api.getFriendsList`](#getFriendsList)
 * [`api.getThreadHistory`](#getThreadHistory)
 * [`api.getThreadInfo`](#getThreadInfo)
@@ -437,6 +438,41 @@ Returns current appState which can be saved to a file or stored in a variable.
 ### api.getCurrentUserID()
 
 Returns the currently logged-in user's Facebook user ID.
+
+---------------------------------------
+
+<a name="getEmojiUrl"></a>
+### api.getEmojiUrl(c, size[, pixelRatio])
+
+Returns the URL to a Facebook Messenger-style emoji image asset.
+
+__note__: This function will return a URL regardless of whether the image at the URL actually exists.
+This can happen if, for example, Messenger does not have an image asset for the requested emoji.
+
+__Arguments__
+
+* `c` - The emoji character
+* `size` - The width and height of the emoji image; supported sizes are 32, 64, and 128
+* `pixelRatio` - The pixel ratio of the emoji image; supported ratios are '1.0' and '1.5' (default is '1.0')
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if(err) return console.error(err);
+
+    // Prints https://static.xx.fbcdn.net/images/emoji.php/v8/z9c/1.0/128/1f40d.png
+    console.log('Snake emoji, 128px (128x128 with pixel ratio of 1.0');
+    console.log(api.getEmojiUrl('\ud83d\udc0d', 128));
+
+    // Prints https://static.xx.fbcdn.net/images/emoji.php/v8/ze1/1.5/128/1f40d.png
+    console.log('Snake emoji, 192px (128x128 with pixel ratio of 1.5');
+    console.log(api.getEmojiUrl('\ud83d\udc0d', 128, '1.5'));
+});
+```
 
 ---------------------------------------
 

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ function buildAPI(globalOptions, html, jar) {
     'deleteThread',
     'forwardAttachment',
     'getCurrentUserID',
+    'getEmojiUrl',
     'getFriendsList',
     'getThreadHistory',
     'getThreadInfo',

--- a/src/getEmojiUrl.js
+++ b/src/getEmojiUrl.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const utils = require("../utils");
+const util = require("util");
 
 module.exports = function() {
   return function getEmojiUrl(c, size, pixelRatio) {

--- a/src/getEmojiUrl.js
+++ b/src/getEmojiUrl.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const utils = require("../utils");
+
+module.exports = function() {
+  return function getEmojiUrl(c, size, pixelRatio) {
+    /*
+     Resolves Facebook Messenger emoji image asset URL for an emoji character.
+     Supported sizes are 32, 64, and 128.
+     Supported pixel ratios are '1.0' and '1.5' (possibly more; haven't tested)
+     */
+    const baseUrl = 'https://static.xx.fbcdn.net/images/emoji.php/v8/z%s/%s';
+    pixelRatio = pixelRatio || '1.0';
+
+    let ending = util.format('%s/%s/%s.png', pixelRatio, size, c.codePointAt(0).toString(16));
+    let base = 317426846;
+    for (let i = 0; i < ending.length; i++) {
+      base = (base << 5) - base + ending.charCodeAt(i);
+    }
+
+    let hashed = (base & 255).toString(16);
+    return util.format(baseUrl, hashed, ending);
+  };
+};

--- a/utils.js
+++ b/utils.js
@@ -824,25 +824,6 @@ function getAppState(jar){
     .concat(jar.getCookies("https://www.messenger.com"));
 }
 
-function getEmojiUrl(c, size) {
-  /*
-    Resolves Facebook Messenger emoji image asset URL for an emoji character.
-    Supported sizes are 32, 64, and 128.
-    Note that the actual size of the image will be 1.5 times the requested size
-    (size of 128 will return an image that is 192×192px).
-  */
-  const baseUrl = 'https://static.xx.fbcdn.net/images/emoji.php/v8/z%s/%s';
-
-  let ending = util.format('1.5/%s/%s.png', size, c.codePointAt(0).toString(16));
-  let base = 317426846;
-  for (let i = 0; i < ending.length; i++) {
-    base = (base << 5) - base + ending.charCodeAt(i);
-  }
-
-  let hashed = (base & 255).toString(16);
-  return util.format(baseUrl, hashed, ending);
-}
-
 module.exports = {
   isReadableStream: isReadableStream,
   get: get,
@@ -879,5 +860,4 @@ module.exports = {
   formatDate: formatDate,
   decodeClientPayload: decodeClientPayload,
   getAppState: getAppState,
-  getEmojiUrl: getEmojiUrl,
 };

--- a/utils.js
+++ b/utils.js
@@ -824,6 +824,25 @@ function getAppState(jar){
     .concat(jar.getCookies("https://www.messenger.com"));
 }
 
+function getEmojiUrl(c, size) {
+  /*
+    Resolves Facebook Messenger emoji image asset URL for an emoji character.
+    Supported sizes are 32, 64, and 128.
+    Note that the actual size of the image will be 1.5 times the requested size
+    (size of 128 will return an image that is 192×192px).
+  */
+  const baseUrl = 'https://static.xx.fbcdn.net/images/emoji.php/v8/z%s/%s';
+
+  let ending = util.format('1.5/%s/%s.png', size, c.codePointAt(0).toString(16));
+  let base = 317426846;
+  for (let i = 0; i < ending.length; i++) {
+    base = (base << 5) - base + ending.charCodeAt(i);
+  }
+
+  let hashed = (base & 255).toString(16);
+  return util.format(baseUrl, hashed, ending);
+}
+
 module.exports = {
   isReadableStream: isReadableStream,
   get: get,
@@ -860,4 +879,5 @@ module.exports = {
   formatDate: formatDate,
   decodeClientPayload: decodeClientPayload,
   getAppState: getAppState,
+  getEmojiUrl: getEmojiUrl,
 };


### PR DESCRIPTION
#467 

Example usage:
`utils.getEmojiUrl('🐍', 128)` returns `https://static.xx.fbcdn.net/images/emoji.php/v8/ze1/1.5/128/1f40d.png` which is the emoji asset url for the snake emoji:

![🐍](https://static.xx.fbcdn.net/images/emoji.php/v8/ze1/1.5/128/1f40d.png)