### PR TITLE
Add MessageAudio attachment type

### DIFF
--- a/src/getThreadHistoryGraphQL.js
+++ b/src/getThreadHistoryGraphQL.js
@@ -97,6 +97,18 @@ function formatAttachmentsGraphQLResponse(attachment) {
         contentType: attachment.content_type,
         filename: attachment.filename,
       }
+    case "MessageAudio":
+      return {
+        attachmentID: attachment.url_shimhash, // Copied from above
+
+        type: "audio",
+        audioType: attachment.audio_type,
+        durationInMs: attachment.playable_duration_in_ms,
+        url: attachment.playable_url,
+
+        isVoiceMail: attachment.is_voicemail,
+        filename: attachment.filename,
+      }  
     default:
       return {error: "Don't know about attachment type " + attachment.__typename};
   }


### PR DESCRIPTION
Adds `MessageAudio` attachment type to GraphQL version of `getThreadHistory` (`getThreadHistoryGraphQL`). I've tried to keep and copy the naming conventions of the fields from the other attachment types

Think this fixes #383 as well.

I've discard some fields for the user and kept what I think is appropriate but I'd be happy to add/remove any fields that you might think should be changed.