### PR TITLE
Fix sendMessage being unable to tag names

### DIFF
--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -262,6 +262,7 @@ module.exports = function(defaultFuncs, api, ctx) {
         form['profile_xmd[' + i + '][offset]'] = offset;
         form['profile_xmd[' + i + '][length]'] = tag.length;
         form['profile_xmd[' + i + '][id]'] = id;
+	form['profile_xmd[' + i + '][type]'] = 'p';
       }
     }
     cb();


### PR DESCRIPTION
Fix issue where sendMessage is unable to tag other users due to a Facebook change.

https://github.com/Schmavery/facebook-chat-api/issues/507