### PR TITLE
getThreadInfoGraphQL.js:formatExtensibleAttachment() fixes

### DIFF
--- a/src/getThreadHistoryGraphQL.js
+++ b/src/getThreadHistoryGraphQL.js
@@ -134,15 +134,15 @@ function formatExtensibleAttachment(attachment) {
       title: attachment.story_attachment.title_with_entities.text,
       subattachments: attachment.story_attachment.subattachments,
       url: attachment.story_attachment.url,
-      source: attachment.story_attachment.source.text,
-      playable: attachment.story_attachment.media.is_playable,
+      source: (attachment.story_attachment.source != null ? attachment.story_attachment.source.text : ""),
+      playable: (attachment.story_attachment.media != null ? attachment.story_attachment.media.is_playable : ""),
       
       // New
-      thumbnailUrl: (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).uri,
-      thumbnailWidth: (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).width,
-      thumbnailHeight: (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).height,
-      duration: attachment.story_attachment.media.playable_duration_in_ms,
-      playableUrl: attachment.story_attachment.media.playable_url,
+      thumbnailUrl: (attachment.story_attachment.media != null ? (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).uri : ""),
+      thumbnailWidth: (attachment.story_attachment.media != null ? (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).width : ""),
+      thumbnailHeight: (attachment.story_attachment.media != null ? (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).height : ""),
+      duration: (attachment.story_attachment.media != null ? attachment.story_attachment.media.playable_duration_in_ms : ""),
+      playableUrl: (attachment.story_attachment.media != null ? attachment.story_attachment.media.playable_url : ""),
       
       // Format example:
       // 


### PR DESCRIPTION
* Made several attachment field values conditionally null if specified element does not exist.

Previously, `formatExtensibleAttachment()` was failing on certain types of attachments -- i.e., attachments with missing `attachment.story_attachment.source` or `attachment.story_attachment.media` fields.