### PR TITLE
Rewrite presence

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -947,7 +947,7 @@ The message object will contain different fields based on its type (as determine
 	</tr>
 	<tr>
 		<td><code>timestamp</code></td>
-		<td>How old the presence information is.</td>
+		<td>The time when the user was last online.</td>
 	</tr>
 	<tr>
 		<td><code>type</code></td>

--- a/utils.js
+++ b/utils.js
@@ -492,7 +492,7 @@ function formatDeltaMessage(m){
   for (var i = 0; i < m_id.length; i++) {
     mentions[m_id[i]] = m.delta.body.substring(m_offset[i], m_offset[i] + m_length[i]);
   }
-  
+
   return {
     type: "message",
     senderID: formatID(md.actorFbId.toString()),
@@ -683,7 +683,7 @@ function getFrom(str, startToken, endToken) {
 
 function makeParsable(html) {
   var withoutForLoop = html.replace(/for\s*\(\s*;\s*;\s*\)\s*;\s*/, "");
-  
+
   // (What the fuck FB, why windows style newlines?)
   // So sometimes FB will send us base multiple objects in the same response.
   // They're all valid JSON, one after the other, at the top level. We detect
@@ -691,7 +691,7 @@ function makeParsable(html) {
   //       Ben - July 15th 2017
   var maybeMultipleObjects = withoutForLoop.split("}\r\n{");
   if (maybeMultipleObjects.length === 1) return maybeMultipleObjects;
-  
+
   return "[" + maybeMultipleObjects.join("},{") + "]";
 }
 
@@ -718,14 +718,14 @@ function generateTimestampRelative() {
 function makeDefaults(html, userID, ctx) {
   var reqCounter = 1;
   var fb_dtsg = getFrom(html, "name=\"fb_dtsg\" value=\"", "\"");
-  
+
   // @Hack Ok we've done hacky things, this is definitely on top 5.
   // We totally assume the object is flat and try parsing until a }.
   // If it works though it's cool because we get a bunch of extra data things.
-  // 
+  //
   // Update: we don't need this. Leaving it in in case we ever do.
   //       Ben - July 15th 2017
-  
+
   // var siteData = getFrom(html, "[\"SiteData\",[],", "},");
   // try {
   //   siteData = JSON.parse(siteData + "}");
@@ -733,7 +733,7 @@ function makeDefaults(html, userID, ctx) {
   //   log.warn("makeDefaults", "Couldn't parse SiteData. Won't have access to some variables.");
   //   siteData = {};
   // }
-  
+
   var ttstamp = "2";
   for (var i = 0; i < fb_dtsg.length; i++) {
     ttstamp += fb_dtsg.charCodeAt(i);
@@ -745,11 +745,11 @@ function makeDefaults(html, userID, ctx) {
     // After some investigation it seems like __dyn is some sort of set that FB
     // calls BitMap. It seems like certain responses have a "define" key in the
     // res.jsmods arrays. I think the code iterates over those and calls `set`
-    // on the bitmap for each of those keys. Then it calls 
+    // on the bitmap for each of those keys. Then it calls
     // bitmap.toCompressedString() which returns what __dyn is.
-    // 
+    //
     // So far the API has been working without this.
-    // 
+    //
     //              Ben - July 15th 2017
     var newObj = {
       __user: userID,
@@ -763,7 +763,7 @@ function makeDefaults(html, userID, ctx) {
       // __spin_b: siteData.__spin_b,
       // __spin_t: siteData.__spin_t,
     };
-    
+
     // @TODO this is probably not needed.
     //         Ben - July 15th 2017
     // if (siteData.be_key) {
@@ -782,7 +782,7 @@ function makeDefaults(html, userID, ctx) {
         }
       }
     }
-    
+
     return newObj;
   }
 
@@ -852,7 +852,7 @@ function parseAndCheckLogin(ctx, defaultFuncs, retryCount) {
           res: data.body
         };
       }
-      
+
       // TODO: handle multiple cookies?
       if (res.jsmods
           && res.jsmods.require
@@ -864,7 +864,7 @@ function parseAndCheckLogin(ctx, defaultFuncs, retryCount) {
         ctx.jar.setCookie(cookie, "https://www.facebook.com");
         ctx.jar.setCookie(cookie2, "https://www.messenger.com");
       }
-      
+
       // On every request we check if we got a DTSG and we mutate the context so that we use the latest
       // one for the next requests.
       if (res.jsmods
@@ -881,7 +881,7 @@ function parseAndCheckLogin(ctx, defaultFuncs, retryCount) {
             }
           }
         }
-        
+
       }
 
       if (res.error === 1357001) {
@@ -968,12 +968,12 @@ function getType(obj) {
 }
 
 function formatProxyPresence(presence, userID) {
-  if(presence.lat === undefined) return null;
+  if(presence.lat === undefined || presence.p === undefined) return null;
   return {
     type: "presence",
     timestamp: presence.lat * 1000,
     userID: userID,
-    statuses: presence.p === undefined ? 0 : presence.p
+    statuses: presence.p
   };
 }
 


### PR DESCRIPTION
Alright, I think this is now ready. I thought it through many times, and this is the easiest way to reduce the noisiness of the `proxy-presence` thing. If it contains an update (aka a _status code_), it fires, if not, then it won't. What does everyone think about this?

(Fixes #549)