### PR TITLE
Extensible attachment fixes

### DIFF
--- a/src/getThreadHistoryGraphQL.js
+++ b/src/getThreadHistoryGraphQL.js
@@ -129,7 +129,7 @@ function formatExtensibleAttachment(attachment) {
       target:"",
 
       type: "share",
-      description: attachment.story_attachment.description.text,
+      description: attachment.story_attachment.description && attachment.story_attachment.description.text,
       attachmentID: attachment.legacy_attachment_id,
       title: attachment.story_attachment.title_with_entities.text,
       subattachments: attachment.story_attachment.subattachments,

--- a/utils.js
+++ b/utils.js
@@ -231,7 +231,7 @@ function getGUID() {
 function _formatAttachment(attachment1, attachment2) {
   // TODO: THIS IS REALLY BAD
   // This is an attempt at fixing Facebook's inconsistencies. Sometimes they give us
-  // two attachement objects, but sometimes only one. They each contain part of the
+  // two attachment objects, but sometimes only one. They each contain part of the
   // data that you'd want so we merge them for convenience.
   // Instead of having a bunch of if statements guarding every access to image_data,
   // we set it to empty object and use the fact that it'll return undefined.
@@ -442,7 +442,7 @@ function _formatAttachment(attachment1, attachment2) {
     case "ExtensibleAttachment":
       return {
         type: "share",
-        description: blob.story_attachment.description && blob.story_attachement.description.text,
+        description: blob.story_attachment.description && blob.story_attachment.description.text,
         ID: blob.legacy_attachment_id,
         subattachments: blob.story_attachment.subattachments,
         width: blob.story_attachment.media && blob.story_attachment.media.image && blob.story_attachment.media.image.width,


### PR DESCRIPTION
Extensible attachments were returning errors both in listen and getThreadHistoryGraphQL. This fixes the misspelling for the former and the error handling for the latter.