### PR TITLE
Fix some errors on getThreadHistoryGraphQL

### DIFF
--- a/src/getThreadHistoryGraphQL.js
+++ b/src/getThreadHistoryGraphQL.js
@@ -123,9 +123,9 @@ function extractThumbnail(media){
     }
   }
   return {
-    uri : "",
-    width : "",
-    height : ""
+    uri : null,
+    width : null,
+    height : null
   };
 }
 

--- a/src/getThreadHistoryGraphQL.js
+++ b/src/getThreadHistoryGraphQL.js
@@ -114,8 +114,24 @@ function formatAttachmentsGraphQLResponse(attachment) {
   }
 }
 
+function extractThumbnail(media){
+  if (media){
+    var image = media.animated_image || media.image;
+    
+    if(image){
+      return image;
+    }
+  }
+  return {
+    uri : "",
+    width : "",
+    height : ""
+  };
+}
+
 function formatExtensibleAttachment(attachment) {
   if (attachment.story_attachment) {
+    var thumbnail = extractThumbnail(attachment.story_attachment.media);
     return {
       // Deprecated fields
       animatedImageSize: "",
@@ -138,9 +154,9 @@ function formatExtensibleAttachment(attachment) {
       playable: (attachment.story_attachment.media != null ? attachment.story_attachment.media.is_playable : ""),
       
       // New
-      thumbnailUrl: (attachment.story_attachment.media != null ? (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).uri : ""),
-      thumbnailWidth: (attachment.story_attachment.media != null ? (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).width : ""),
-      thumbnailHeight: (attachment.story_attachment.media != null ? (attachment.story_attachment.media.animated_image || attachment.story_attachment.media.image).height : ""),
+      thumbnailUrl: thumbnail.uri,
+      thumbnailWidth: thumbnail.width,
+      thumbnailHeight: thumbnail.height,
       duration: (attachment.story_attachment.media != null ? attachment.story_attachment.media.playable_duration_in_ms : ""),
       playableUrl: (attachment.story_attachment.media != null ? attachment.story_attachment.media.playable_url : ""),
       
@@ -175,6 +191,7 @@ function formatReactionsGraphQL(reaction) {
 }
 
 function formatEventData(event) {
+    if (!event) return {};
   switch (event.__typename) {
     case "ThemeColorExtensibleMessageAdminText":
       return {


### PR DESCRIPTION
Hello,

I recently used getThreadHistoryGraphQL to export my 95 000 messages group chat on facebook. I got some issues regarding this function so I fixed them and I was able to get every messages.