### PR TITLE
Update getThreadHistory to return attachment.story_attachment.target

### DIFF
--- a/src/getThreadHistory.js
+++ b/src/getThreadHistory.js
@@ -224,7 +224,7 @@ function formatExtensibleAttachment(attachment) {
       animatedImageSize: "", // @Legacy
       facebookUrl: "", // @Legacy
       styleList: "", // @Legacy
-      target: "", // @Legacy
+      target: attachment.story_attachment.target, // @Legacy
       thumbnailUrl:
         attachment.story_attachment.media == null
           ? null


### PR DESCRIPTION
We are using `facebook-chat-api` to run end-to-end test for our chatbot. The bot itself uses official FB Messenger API. In the tests we want to assert that expected buttons are shown.

For example, we want to verify that a user receives a message with "Log In" and "Cancel" buttons. After the change the message looks like:
```
{
    "type": "message",
    "body": "I need you to login to your account to link it your Facebook profile before we can continue.",
    "attachments": [
      {
        ...,
        "target": {
          ...
          "call_to_actions": [
            {
              "action_link": "https://l.facebook.com/l.php?...",
              "action_open_type": "OPEN_URL",
              "title": "Log In",
              ...
            },
            {
              "action_link": "https://www.facebook.com/commerce/update/",
              "action_open_type": "POSTBACK",
              "title": "Cancel",
              ...
            }
          ]
        }
      }
    ],
    ...
  }
```

Note: in case non-GraphQL response (using `utils.js`) the target field is available and it works for us, but with the recent FB changes, we forced to use GraphQL to load a message, see https://github.com/Schmavery/facebook-chat-api/pull/628