### PR TITLE
Rename domain www.facebook.com to web.facebook.com

### DIFF
--- a/src/getUserID.js
+++ b/src/getUserID.js
@@ -33,7 +33,7 @@ module.exports = function(defaultFuncs, api, ctx) {
     };
 
     defaultFuncs
-      .get("https://www.facebook.com/ajax/typeahead/search.php", ctx.jar, form)
+      .get("https://web.facebook.com/ajax/typeahead/search.php", ctx.jar, form)
       .then(utils.parseAndCheckLogin(ctx, defaultFuncs))
       .then(function(resData) {
         if (resData.error) {


### PR DESCRIPTION
for changes of facebook, this is  minimal change, is solution to problem, when execute getUserID.