### PR TITLE
Follow redirects on GET requests

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1053,6 +1053,13 @@ function parseAndCheckLogin(ctx, defaultFuncs, retryCount) {
           res: data.body
         };
       }
+      
+      // In some cases the response contains only a redirect URL which should be followed
+      if (res.redirect && data.request.method === "GET") {
+        return defaultFuncs
+        .get(res.redirect, ctx.jar)
+        .then(parseAndCheckLogin(ctx, defaultFuncs));
+      }
 
       // TODO: handle multiple cookies?
       if (


### PR DESCRIPTION
Follow up to #604 and fixes #632
Redirecting on the main page (#604) doesn't fix everything on the affected networks, as some GET requests (particularly the getUserID function) return an object with the proper URL they should redirect to. 