### PR TITLE
Moved prettier to dev-dependencies, fixed scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.5.1",
   "description": "Facebook chat API that doesn't rely on XMPP.  Will NOT be deprecated April 30th 2015.",
   "scripts": {
-    "test": "node_modules/.bin/mocha",
-    "prettier": "node_modules/.bin/prettier utils.js src/* --write"
+    "test": "mocha",
+    "prettier": "prettier utils.js src/* --write"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Facebook chat API that doesn't rely on XMPP.  Will NOT be deprecated April 30th 2015.",
   "scripts": {
     "test": "node_modules/.bin/mocha",
-    "start": "node server.js",
-    "prettier": "prettier utils.js src/* --write"
+    "prettier": "node_modules/.bin/prettier utils.js src/* --write"
   },
   "repository": {
     "type": "git",
@@ -25,13 +24,13 @@
     "bluebird": "^2.9.27",
     "cheerio": "^0.19.0",
     "npmlog": "^1.2.0",
-    "prettier": "^1.11.1",
     "request": "^2.53.0"
   },
   "engines": {
     "node": ">=4.x"
   },
   "devDependencies": {
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "prettier": "^1.11.1"
   }
 }


### PR DESCRIPTION
(saves 7,46MB of download on `npm install`)