### PR TITLE
Add getLastNotifications Command (#644)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -16,6 +16,7 @@
 * [`api.getCurrentUserID`](#getCurrentUserID)
 * [`api.getEmojiUrl`](#getEmojiUrl)
 * [`api.getFriendsList`](#getFriendsList)
+* [`api.getLastNotifications`](#getLastNotifications)
 * [`api.getThreadHistory`](#getThreadHistory)
 * [`api.getThreadInfo`](#getThreadInfo)
 * [`api.getThreadList`](#getThreadList)
@@ -499,6 +500,33 @@ login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, ap
         if(err) return console.error(err);
 
         console.log(data.length);
+    });
+});
+```
+
+---------------------------------------
+<a name="getLastNotifications"></a>
+### api.getLastNotifications(callback)
+
+Returns an array of objects with the last notifications of the profile.
+
+__Arguments__
+
+* `callback(err, arr)` - A callback called when the query is done (either with an error or with an confirmation object). `arr` is an array of objects with the following fields: `id`, `type`, `thumbnail`, `icon`, `state`, `first_read_time`, `first_seen_time`, `message`, `url`, `creation_time`, `time_text`, `time_verbose`, `alert_id`, `sort_keys`, `previewImage`, `tracking`.
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if(err) return console.error(err);
+
+    api.getLastNotifications((err, data) => {
+        if(err) return console.error(err);
+
+        console.log(data.message);
     });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Result:
 * [`api.getAppState`](DOCS.md#getAppState)
 * [`api.getCurrentUserID`](DOCS.md#getCurrentUserID)
 * [`api.getFriendsList`](DOCS.md#getFriendsList)
+* [`api.getLastNotifications`](DOCS.md#getLastNotifications)
 * [`api.getThreadHistory`](DOCS.md#getThreadHistory)
 * [`api.getThreadInfo`](DOCS.md#getThreadInfo)
 * [`api.getThreadList`](DOCS.md#getThreadList)

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ function buildAPI(globalOptions, html, jar) {
     'getCurrentUserID',
     'getEmojiUrl',
     'getFriendsList',
+    'getLastNotifications',
     'getThreadHistory',
     'getThreadInfo',
     'getThreadList',

--- a/src/getLastNotifications.js
+++ b/src/getLastNotifications.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const utils = require("../utils");
+const log = require("npmlog");
+
+function getTransportedNotif (NST)
+{
+  // This function get the `nodes` array with notifications from Notification
+  // Server Transport module. The index are arbitrary according to response
+  // format.
+  return (NST && NST[3] && NST[3][1] && NST[3][1].nodes) || null;
+}
+
+function getTrackingJSON (tracking)
+{
+  try{
+    return JSON.parse(tracking);
+  }catch(e){
+    return null;
+  }
+}
+
+function formatNotificationNode (node)
+{
+  return {
+    id: node.id,
+    type: node.notif_type,
+    thumbnail: (node.thumbnail && node.thumbnail.uri) || null,
+    icon: (node.icon && node.icon.uri) || null,
+    state: node.seen_state,
+    first_read_time: node.first_read_time,
+    first_seen_time: node.first_seen_time,
+    message: (node.title && node.title.text) || null,
+    url: node.url,
+    creation_time: node.creation_time,
+    time_text: node.timestamp.text,
+    time_verbose: node.timestamp.verbose,
+    alert_id: node.alert_id,
+    sort_keys: node.sort_keys,
+    previewImage: node.previewImage,
+    tracking: getTrackingJSON (node.tracking),
+  };
+}
+
+module.exports = function(defaultFuncs, api, ctx) {
+  return function getLastNotifications(callback) {
+    if ((utils.getType(callback) !== "Function") && (utils.getType(callback) !== "AsyncFunction")) {
+      throw {error: "getLastNotifications: need callback"};
+    }
+
+    const form = {
+      data: JSON.stringify({
+        "businessUserID":null,
+        "length":10,
+        "clientRequestID":"js_3u",
+      }),
+      'no_script_path': 1,
+      '__a':1,
+    };
+
+    defaultFuncs
+      .get(
+        "https://www.facebook.com/ajax/pagelet/generic.php/WebNotificationsPayloadPagelet",
+        ctx.jar,
+        form
+      )
+      .then(utils.parseAndCheckLogin(ctx, defaultFuncs))
+      .then(function(resData) {
+        if (resData.error) {
+          throw resData;
+        }
+
+        // `jsmods.require` will return and array of modules, we should filter
+        // the specific module we want. I found it at least two times in the
+        // list, because of this, it's better the algorithm pass through all
+        // of them.
+        var node, transport_nodes, resulting_array = [];
+        for (var reqItem of resData.jsmods.require) {
+          if (reqItem[0] !== 'NotificationServerTransport') {
+            continue;
+          }
+          transport_nodes = getTransportedNotif (reqItem);
+          if (! transport_nodes) {
+            continue;
+          }
+          for (node of transport_nodes) {
+            resulting_array.push (formatNotificationNode (node));
+          }
+        }
+        return callback(null, resulting_array);
+      })
+      .catch(function(err) {
+        log.error("getLastNotifications", err);
+        return callback(err);
+      });
+  };
+};

--- a/test/test.js
+++ b/test/test.js
@@ -375,6 +375,15 @@ describe('Login:', function() {
     assert(formatted.attachments[0].target.items[0].call_to_actions[0].title === "Google");
   });
 
+  it('should get last notifications from user profile', function (done){
+      api.getLastNotifications((err, info) => {
+        if (err) done(err);
+        assert(info.length > 0);
+        assert(info[0].id != undefined);
+        done();
+      });
+  });
+
   it('should log out', function (done) {
     api.logout(done);
   });


### PR DESCRIPTION
In issue #644 I was discussing a personal need I had. Now I have made a command to fit my needs: it makes a request and gets a list of the last notifications of the currently logged user.

As it is not a Messenger thing, but an FB thing, I don't know if it's expected to be in the official Unofficial Facebook Chat API. I will maintain a fork for a while and use it from that, if you like the function and think it can be somewhat useful, I am opening a pull request.

The initial commit includes source, documentation, and test for the getLastNotification command.

If you are willing to accept the pull request, please review the additions and inform me of any problem related to code, formatting or grammar (English is not my native language).