### PR TITLE
Add changeAdminStatus

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -2,6 +2,7 @@
 
 * [`login`](#login)
 * [`api.addUserToGroup`](#addUserToGroup)
+* [`api.changeAdminStatus`](#changeAdminStatus)
 * [`api.changeArchivedStatus`](#changeArchivedStatus)
 * [`api.changeBlockedStatus`](#changeBlockedStatus)
 * [`api.changeGroupImage`](#changeGroupImage)
@@ -170,6 +171,34 @@ __Arguments__
 * `userID`: User ID or array of user IDs.
 * `threadID`: Group chat ID.
 * `callback(err)`: A callback called when the query is done (either with an error or with no arguments).
+
+---------------------------------------
+
+<a name="changeAdminStatus"></a>
+### api.changeAdminStatus(userIDs, makeAdmin, threadID[, callback])
+
+Given a userID, or an array of userIDs, will set the admin status of the user(s) to `makeAdmin`.
+
+__Arguments__
+* `userIDs`: The id(s) of users you wish to admin/unadmin (either a string indicating a user's ID or an array of them).
+* `makeAdmin`: Boolean indicating whether the user(s) should be promoted to admin (`true`) or demoted to a regular user (`false`).
+* `callback(err)`: A callback called when the query is done (either with an error or null).
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if(err) return console.error(err);
+
+    // Makes user 000000000000000 an admin in thread 111111111111111
+    api.changeAdminStatus("000000000000000", true, "111111111111111", (err) => {
+        if(err) return console.error(err);
+    });
+});
+```
 
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Result:
 
 * [`login`](DOCS.md#login)
 * [`api.addUserToGroup`](DOCS.md#addUserToGroup)
+* [`api.changeAdminStatus`](DOCS.md#changeAdminStatus)
 * [`api.changeArchivedStatus`](DOCS.md#changeArchivedStatus)
 * [`api.changeBlockedStatus`](DOCS.md#changeBlockedStatus)
 * [`api.changeGroupImage`](DOCS.md#changeGroupImage)

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ function buildAPI(globalOptions, html, jar) {
     'changeGroupImage',
     'changeThreadColor',
     'changeThreadEmoji',
+    'changeAdminStatus',
     'changeNickname',
     'createPoll',
     'deleteMessage',

--- a/src/changeAdminStatus.js
+++ b/src/changeAdminStatus.js
@@ -1,0 +1,78 @@
+"use strict";
+
+var utils = require("../utils");
+var log = require("npmlog");
+
+module.exports = function(defaultFuncs, api, ctx) {
+  return function changeAdminStatus(userIDs, makeAdmin, threadID, callback) {
+    if (
+      !callback &&
+      (utils.getType(makeAdmin) === "AsyncFunction" ||
+        utils.getType(makeAdmin) === "AsyncFunction" ||
+        utils.getType(threadID) === "Function" ||
+        utils.getType(threadID) === "AsyncFunction")
+    ) {
+      throw { error: "please pass makeAdmin and threadID as the second/third arguments." };
+    }
+
+    if (utils.getType(userIDs) === "String") {
+      userIDs = [userIDs];
+    }
+
+    if (!callback) {
+      callback = function() {};
+    }
+
+    var messageAndOTID = utils.generateOfflineThreadingID();
+    var form = {
+      client: "mercury",
+      action_type: "ma-type:log-message",
+      author: "fbid:" + ctx.userID,
+      author_email: "",
+      coordinates: "",
+      timestamp: Date.now(),
+      timestamp_absolute: "Today",
+      timestamp_relative: utils.generateTimestampRelative(),
+      timestamp_time_passed: "0",
+      is_unread: false,
+      is_cleared: false,
+      is_forward: false,
+      is_filtered_content: false,
+      is_spoof_warning: false,
+      source: "source:chat:web",
+      "source_tags[0]": "source:chat",
+      status: "0",
+      offline_threading_id: messageAndOTID,
+      message_id: messageAndOTID,
+      threading_id: utils.generateThreadingID(ctx.clientID),
+      manual_retry_cnt: "0",
+      thread_fbid: threadID,
+      add: makeAdmin,
+      thread_id: threadID,
+      log_message_type: "log:thread-name"
+    };
+
+    for (var i = 0; i < userIDs.length; i++) {
+      form["admin_ids[" + i + "]"] = userIDs[i];
+    }
+
+    defaultFuncs
+      .post("https://www.messenger.com/messaging/save_admins/", ctx.jar, form)
+      .then(utils.parseAndCheckLogin(ctx, defaultFuncs))
+      .then(function(resData) {
+        if (resData.error && resData.error === 1976004) {
+          throw { error: "Cannot alter admin status: you are not an admin." };
+        }
+
+        if (resData.error) {
+          throw resData;
+        }
+
+        return callback();
+      })
+      .catch(function(err) {
+        log.error("changeAdminStatus", err);
+        return callback(err);
+      });
+  };
+};

--- a/src/changeAdminStatus.js
+++ b/src/changeAdminStatus.js
@@ -64,6 +64,10 @@ module.exports = function(defaultFuncs, api, ctx) {
           throw { error: "Cannot alter admin status: you are not an admin." };
         }
 
+        if (resData.error && resData.error === 1357031) {
+          throw { error: "Cannot alter admin status: this thread is not a group chat." };
+        }
+
         if (resData.error) {
           throw resData;
         }


### PR DESCRIPTION
Adds a `changeAdminStatus` function to allow the API to alter the admin status of users in group chats (naming suggestions welcome).

re: #624 