### PR TITLE
Add api.changeAdminStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-## 1.5.0 (unreleased)
+## 1.6.1 (unreleased)
+* [New] [changeAdminStatus](/DOCS.md#changeAdminStatus): Function to add/remove admins in group threads ([#659](https://github.com/Schmavery/facebook-chat-api/pull/659))
+
+## 1.5.0
 * [Fix] Logging in using login approvals (2FA) now work ([#548](https://github.com/Schmavery/facebook-chat-api/pull/548))
 * [New] [listen](/DOCS.md#listen): Adds field `mentions` that stores an array of ids of users tagged in the message ([#510](https://github.com/Schmavery/facebook-chat-api/pull/510))
 * [Breaking change] [getThreadList](/DOCS.md#getThreadList): Removes deprecated fields in returned object, adds some new fields ([#488](https://github.com/Schmavery/facebook-chat-api/pull/488))

--- a/DOCS.md
+++ b/DOCS.md
@@ -2,6 +2,7 @@
 
 * [`login`](#login)
 * [`api.addUserToGroup`](#addUserToGroup)
+* [`api.changeAdminStatus`](#changeAdminStatus)
 * [`api.changeArchivedStatus`](#changeArchivedStatus)
 * [`api.changeBlockedStatus`](#changeBlockedStatus)
 * [`api.changeGroupImage`](#changeGroupImage)
@@ -22,7 +23,6 @@
 * [`api.getThreadPictures`](#getThreadPictures)
 * [`api.getUserID`](#getUserID)
 * [`api.getUserInfo`](#getUserInfo)
-* [`api.threadColors`](#threadColors)
 * [`api.handleMessageRequest`](#handleMessageRequest)
 * [`api.listen`](#listen)
 * [`api.logout`](#logout)
@@ -36,6 +36,7 @@
 * [`api.setMessageReaction`](#setMessageReaction)
 * [`api.setOptions`](#setOptions)
 * [`api.setTitle`](#setTitle)
+* [`api.threadColors`](#threadColors)
 
 ---------------------------------------
 
@@ -170,6 +171,43 @@ __Arguments__
 * `userID`: User ID or array of user IDs.
 * `threadID`: Group chat ID.
 * `callback(err)`: A callback called when the query is done (either with an error or with no arguments).
+
+---------------------------------------
+
+<a name="changeAdminStatus"></a>
+### api.changeAdminStatus(threadID, adminIDs, adminStatus[, callback])
+
+Given a adminID, or an array of adminIDs, will set the admin status of the user(s) to `adminStatus`.
+
+__Arguments__
+* `threadID`: ID of a group chat (can't use in one-to-one conversations)
+* `adminIDs`: The id(s) of users you wish to admin/unadmin (string or an array).
+* `adminStatus`: Boolean indicating whether the user(s) should be promoted to admin (`true`) or demoted to a regular user (`false`).
+* `callback(err)`: A callback called when the query is done (either with an error or null).
+
+__Example__
+
+```js
+const fs = require("fs");
+const login = require("facebook-chat-api");
+
+login({appState: JSON.parse(fs.readFileSync('appstate.json', 'utf8'))}, (err, api) => {
+    if (err) return console.error(err);
+
+    let threadID = "0000000000000000";
+    let newAdmins = ["111111111111111", "222222222222222"];
+    api.changeAdminStatus(threadID, newAdmins, true, editAdminsCallback);
+
+    let adminToRemove = "333333333333333";
+    api.changeAdminStatus(threadID, adminToRemove, false, editAdminsCallback);
+
+});
+
+function editAdminsCallback(err) {
+    if (err) return console.error(err);
+}
+
+```
 
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Result:
 
 * [`login`](DOCS.md#login)
 * [`api.addUserToGroup`](DOCS.md#addUserToGroup)
+* [`api.changeAdminStatus`](DOCS.md#changeAdminStatus)
 * [`api.changeArchivedStatus`](DOCS.md#changeArchivedStatus)
 * [`api.changeBlockedStatus`](DOCS.md#changeBlockedStatus)
 * [`api.changeGroupImage`](DOCS.md#changeGroupImage)

--- a/index.js
+++ b/index.js
@@ -75,14 +75,15 @@ function buildAPI(globalOptions, html, jar) {
     },
   };
 
-  var apiFuncNames = [
+  const apiFuncNames = [
     'addUserToGroup',
+    'changeAdminStatus',
     'changeArchivedStatus',
     'changeBlockedStatus',
     'changeGroupImage',
+    'changeNickname',
     'changeThreadColor',
     'changeThreadEmoji',
-    'changeNickname',
     'createPoll',
     'deleteMessage',
     'deleteThread',
@@ -96,7 +97,6 @@ function buildAPI(globalOptions, html, jar) {
     'getThreadPictures',
     'getUserID',
     'getUserInfo',
-    'threadColors',
     'handleMessageRequest',
     'listen',
     'logout',
@@ -109,6 +109,7 @@ function buildAPI(globalOptions, html, jar) {
     'sendTypingIndicator',
     'setMessageReaction',
     'setTitle',
+    'threadColors',
 
     // Deprecated features
     "getThreadListDeprecated",

--- a/src/changeAdminStatus.js
+++ b/src/changeAdminStatus.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const utils = require("../utils");
+const log = require("npmlog");
+
+module.exports = function(defaultFuncs, api, ctx) {
+  return function changeAdminStatus(threadID, adminIDs, adminStatus, callback) {
+    if (utils.getType(threadID) !== "String") {
+      throw {error: "changeAdminStatus: threadID must be a string"};
+    }
+
+    if (utils.getType(adminIDs) === "String") {
+      adminIDs = [adminIDs];
+    }
+
+    if (utils.getType(adminIDs) !== "Array") {
+      throw {error: "changeAdminStatus: adminIDs must be an array or string"};
+    }
+
+    if (utils.getType(adminStatus) !== "Boolean") {
+      throw {error: "changeAdminStatus: adminStatus must be a string"};
+    }
+
+    if (!callback) {
+      callback = () => {};
+    }
+
+    if (utils.getType(callback) !== "Function" && utils.getType(callback) !== "AsyncFunction") {
+      throw {error: "changeAdminStatus: callback is not a function"};
+    }
+
+    let form = {
+      "thread_fbid": threadID,
+    };
+
+    let i = 0;
+    for (let u of adminIDs) {
+      form[`admin_ids[${i++}]`] = u
+    }
+    form["add"] = adminStatus;
+
+    defaultFuncs
+      .post("https://www.messenger.com/messaging/save_admins/?dpr=1", ctx.jar, form)
+      .then(utils.parseAndCheckLogin(ctx, defaultFuncs))
+      .then(function(resData) {
+        if (resData.error) {
+          switch (resData.error) {
+            case 1976004:
+              throw { error: "Cannot alter admin status: you are not an admin.", rawResponse: resData };
+            case 1357031:
+              throw { error: "Cannot alter admin status: this thread is not a group chat.", rawResponse: resData };
+            default:
+              throw { error: "Cannot alter admin status: unknown error.", rawResponse: resData };
+          }
+        }
+
+        callback();
+      })
+      .catch(function(err) {
+        log.error("changeAdminStatus", err);
+        return callback(err);
+      });
+  };
+};
+


### PR DESCRIPTION
few days ago I've made similar function to #658
But I didn't have time to write docs so I didn't pushed it to Github
It looks a bit cleaner IMO

I've also done some tests in the wild
and you can change `adminStatus` of every user in thread without being blocked by Facebook

but if you try to do the same thing one by one... Facebook blocks you for an hour :(

![obraz](https://user-images.githubusercontent.com/3875202/41386902-4fe118ba-6f84-11e8-8f01-906326920149.png)
