### PR TITLE
Use rule prettier for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,18 +33,21 @@
   "devDependencies": {
     "mocha": "^2.2.5",
     "prettier": "^1.11.1",
-    "eslint": "^4.19.1"
+    "eslint": "^4.19.1",
+    "eslint-plugin-prettier": "^3.0.0"
   },
   "eslintConfig": {
     "env": {
       "es6": true,
       "node": true
     },
+    "plugins": ["prettier"],
     "extends": "eslint:recommended",
     "parserOptions": {
       "sourceType": "module"
     },
     "rules": {
+      "prettier/prettier": "error",
       "linebreak-style": [
         "error",
         "unix"


### PR DESCRIPTION
I know that this commit run with error with travis-ci
Because some commit don't run with `prettier`.

If accept this commit and fix your code with `prettier` once, any pull request will error if they don't run `prettier` before commit (use one style in code).