### PR TITLE
Added unsendMessage to apiFuncNames in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ function buildAPI(globalOptions, html, jar) {
     'setMessageReaction',
     'setTitle',
     'threadColors',
+    'unsendMessage',
 
     // Deprecated features
     "getThreadListDeprecated",


### PR DESCRIPTION
Added `unsendMessage `to `apiFuncNames`, not doing this results in a `TypeError: api.unsendMessage is not a function`