### PR TITLE
[docs] Define obj variable in docs for login with login approvals/2fa

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -137,6 +137,7 @@ var rl = readline.createInterface({
   output: process.stdout
 });
 
+const obj = {email: "FB_EMAIL", password: "FB_PASSWORD"};
 login(obj, (err, api) => {
     if(err) {
         switch (err.error) {


### PR DESCRIPTION
The current docs for [login](https://github.com/Schmavery/facebook-chat-api/blob/master/DOCS.md#login) have a slight error in the code for login approvals/2 factor auth. In the code example, a variable `obj` is used, but it is not defined, resulting in a `ReferenceError`. This diff adds a definition for `obj` in the code example.