### PR TITLE
Fix incorrect error assumption in sendMessage

### DIFF
--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -348,7 +348,7 @@ module.exports = function(defaultFuncs, api, ctx) {
       });
     }
     
-    if (messageIDType !== "String") {
+    if (replyToMessage && messageIDType !== 'String') {
       return callback({
         error:
           "MessageID should be of type string and not " +


### PR DESCRIPTION
Hello. If I use `api.sendMessage` without the last argument (reply message id), I get `MessageID should be of type string and not String.` So I fixed it in this PR.