### PR TITLE
Update getThreadHistory.js

### DIFF
--- a/src/getThreadHistory.js
+++ b/src/getThreadHistory.js
@@ -364,7 +364,7 @@ function formatMessagesGraphQLResponse(data) {
         // Give priority to stickers. They're seen as normal messages but we've
         // been considering them as attachments.
         var maybeStickerAttachment;
-        if (d.sticker) {
+        if (d.sticker && d.sticker.pack) {
           maybeStickerAttachment = [
             {
               type: "sticker",


### PR DESCRIPTION
I'm seeing failures on line 374, cannot get 'id' of null.  This fix obviously protects the code and prevents the error, but I have no idea of any underlining consequences Raised as issue #824