### PR TITLE
Add listenMqtt to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Result:
 * [`api.getUserInfo`](DOCS.md#getUserInfo)
 * [`api.handleMessageRequest`](DOCS.md#handleMessageRequest)
 * [`api.listen`](DOCS.md#listen)
+* [`api.listenMqtt`](DOCS.md#listenMqtt)
 * [`api.logout`](DOCS.md#logout)
 * [`api.markAsRead`](DOCS.md#markAsRead)
 * [`api.markAsReadAll`](DOCS.md#markAsReadAll)


### PR DESCRIPTION
The method list in the `DOCS.md` file contains a link to the `listenMqtt` method, but the method list in the main `README.md` file does not include this. As a result, it is unclear that this method is available to someone browsing through the documentation from the readme — for instance, as I was using the API, I only saw the readme initially and assumed the `listen` method was the only way to listen for messages.