### PR TITLE
Change the way of checking if an ID is a user or a group when sending messages

### DIFF
--- a/src/sendMessage.js
+++ b/src/sendMessage.js
@@ -179,18 +179,13 @@ module.exports = function(defaultFuncs, api, ctx) {
     if (utils.getType(threadID) === "Array") {
       sendContent(form, threadID, false, messageAndOTID, callback);
     } else {
-      api.getUserInfo(threadID, function(err, res) {
-        if (err) {
-          return callback(err);
-        }
-        sendContent(
-          form,
-          threadID,
-          Object.keys(res).length > 0,
-          messageAndOTID,
-          callback
-        );
-      });
+      sendContent(
+        form,
+        threadID,
+        threadID.length === 15,
+        messageAndOTID,
+        callback
+      );
     }
   }
 


### PR DESCRIPTION
Calling many times getUserInfo very quickly can block this function and then sending messages becomes impossible, this way we're not calling this function when sending messages. Tested in groups and private messaging and it does work.